### PR TITLE
Put data plane on a single thread

### DIFF
--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -30,12 +30,12 @@ fn main() {
         .unwrap_or(8008);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
-      .enable_all()
-      .build()
-      .expect("Failed to build tokio runtime in data plane");
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime in data plane");
 
     runtime.block_on(async move {
-      tokio::join!(start(data_plane_port), start_health_check_server());
+        tokio::join!(start(data_plane_port), start_health_check_server());
     });
 }
 


### PR DESCRIPTION
# Why
Data plane is scheduling on all threads, which causing contention with the customer process.

# How
- Remove tokio main macro
- Build single current thread runtime
