### PR TITLE
Bump openssl from 0.10.57 to 0.10.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,9 +2245,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -2286,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -30,7 +30,7 @@ cadence-macros = "0.29.0"
 async-trait = "0.1.56"
 mockall = "0.11.4"
 axum = "0.6.19"
-openssl = { version = "0.10.48", features = ["vendored"] }
+openssl = { version = "0.10.60", features = ["vendored"] }
 base64 = "0.13.0"
 storage-client-interface = "0.2.0"
 log = { version = "0.4.19", features = ["max_level_debug"] }

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Evervault <engineering@evervault.com>"]
 [dependencies]
 hyper = { version = "0.14.4", features = ["server","http1","http2","tcp","stream","client"] }
 tokio = { version = "1.24.2", features = ["net", "macros", "rt", "rt-multi-thread", "io-util", "time"] }
-openssl = { version = "0.10.55", features = ["vendored"] }
+openssl = { version = "0.10.60", features = ["vendored"] }
 chrono =  { version = "0.4.22", default-features = false, features = ["serde"]}
 aws-nitro-enclaves-nsm-api = "0.2.1"
 aws-nitro-enclaves-cose = "0.5.0"

--- a/data-plane/src/crypto/token.rs
+++ b/data-plane/src/crypto/token.rs
@@ -68,10 +68,8 @@ impl TokenClient {
     #[cfg(feature = "enclave")]
     fn get_attestation_doc_token(nonce: Vec<u8>) -> Result<String, TokenError> {
         use crate::crypto::attest;
-        use openssl::base64::encode_block;
-
         let attestation_doc = attest::get_attestation_doc(None, Some(nonce))?;
-        Ok(encode_block(&attestation_doc))
+        Ok(base64::encode(&attestation_doc))
     }
 
     #[cfg(not(feature = "enclave"))]

--- a/data-plane/src/crypto/token.rs
+++ b/data-plane/src/crypto/token.rs
@@ -69,7 +69,7 @@ impl TokenClient {
     fn get_attestation_doc_token(nonce: Vec<u8>) -> Result<String, TokenError> {
         use crate::crypto::attest;
         let attestation_doc = attest::get_attestation_doc(None, Some(nonce))?;
-        Ok(base64::encode(&attestation_doc))
+        Ok(base64::encode(attestation_doc))
     }
 
     #[cfg(not(feature = "enclave"))]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -27,7 +27,7 @@ tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 sys-info = "0.9.1"
 cadence = "0.29.0"
 httparse = "1.8.0"
-openssl = { version = "0.10.48", features = ["vendored"] }
+openssl = { version = "0.10.60", features = ["vendored"] }
 base64 = "0.13.0"
 env_logger = "0.10.0"
 once_cell = { version = "1.19.0", optional = true }


### PR DESCRIPTION
# Why
Taken from Dependabot [PR#164](https://github.com/evervault/enclaves/pulls/164)

# How
Bumps [openssl](https://github.com/sfackler/rust-openssl) from 0.10.57 to 0.10.60.
- [Release notes](https://github.com/sfackler/rust-openssl/releases)
- [Commits](https://github.com/sfackler/rust-openssl/compare/openssl-v0.10.57...openssl-v0.10.60)