### PR TITLE
Resolve static compilation of ip

### DIFF
--- a/.github/workflows/test-runtime-builder.yml
+++ b/.github/workflows/test-runtime-builder.yml
@@ -19,3 +19,19 @@ jobs:
         with:
           name: runtime-dependencies-${{github.sha}}.zip
           path: ./output/runtime-dependencies.tar.gz
+  test-installer-on-multiple-runtimes:
+    needs: run-build-on-runtime-installer
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dockerfile: [test-abyss.Dockerfile, test-alpine.Dockerfile, test.Dockerfile]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: runtime-dependencies-${{github.sha}}.zip
+          path: ./output
+      - name: Build image
+        run: |
+          docker build --platform linux/amd64 -t runtime-dependencies-test -f ${{matrix.dockerfile}} .

--- a/.github/workflows/test-runtime-builder.yml
+++ b/.github/workflows/test-runtime-builder.yml
@@ -31,7 +31,8 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: runtime-dependencies-${{github.sha}}.zip
-          path: ./output
+          path: ./installer/output
       - name: Build image
         run: |
+          cd ./installer
           docker build --platform linux/amd64 -t runtime-dependencies-test -f ${{matrix.dockerfile}} .

--- a/.github/workflows/test-runtime-builder.yml
+++ b/.github/workflows/test-runtime-builder.yml
@@ -36,3 +36,4 @@ jobs:
         run: |
           cd ./installer
           docker build --platform linux/amd64 -t runtime-dependencies-test -f ${{matrix.dockerfile}} .
+          docker run --platform linux/amd64 -t runtime-dependencies-test

--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -1,7 +1,7 @@
-FROM --platform=linux/amd64 debian:bookworm
+FROM --platform=linux/amd64 alpine
 
 RUN mkdir -p /packages
-RUN apt-get update ; apt-get install -y pkg-config make gcc bash curl bison flex xz-utils bzip2
+RUN apk update ; apk add xz make gcc build-base bash linux-headers curl pkgconfig bison flex
 
 ADD http://smarden.org/runit/runit-2.1.2.tar.gz /packages/runit-2.1.2.tar.gz
 ADD https://downloads.sourceforge.net/project/net-tools/net-tools-2.10.tar.xz /packages/net-tools-2.10.tar.xz
@@ -9,7 +9,7 @@ ADD https://downloads.sourceforge.net/project/net-tools/net-tools-2.10.tar.xz /p
 RUN curl -o /packages/libmnl-1.0.4.tar.bz2 https://www.netfilter.org/projects/libmnl/files/libmnl-1.0.4.tar.bz2
 RUN curl -o /packages/iptables-1.8.10.tar.xz https://www.netfilter.org/projects/iptables/files/iptables-1.8.10.tar.xz
 RUN curl -o /packages/libnftnl-1.2.6.tar.xz https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.2.6.tar.xz
-RUN curl -o /packages/iproute2-5.19.0.tar.gz https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/snapshot/iproute2-5.19.0.tar.gz
+RUN curl -o /packages/iproute2-6.7.0.tar.gz https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/snapshot/iproute2-6.7.0.tar.gz
 
 # Copy in minimal preset header file to configure net-tools compilation
 COPY config/net-tools.h /packages/

--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -1,7 +1,7 @@
-FROM --platform=linux/amd64 alpine
+FROM --platform=linux/amd64 debian:bookworm
 
 RUN mkdir -p /packages
-RUN apk update ; apk add xz make gcc build-base bash linux-headers curl pkgconfig
+RUN apt-get update ; apt-get install -y pkg-config make gcc bash curl bison flex
 
 ADD http://smarden.org/runit/runit-2.1.2.tar.gz /packages/runit-2.1.2.tar.gz
 ADD https://downloads.sourceforge.net/project/net-tools/net-tools-2.10.tar.xz /packages/net-tools-2.10.tar.xz
@@ -9,6 +9,7 @@ ADD https://downloads.sourceforge.net/project/net-tools/net-tools-2.10.tar.xz /p
 RUN curl -o /packages/libmnl-1.0.4.tar.bz2 https://www.netfilter.org/projects/libmnl/files/libmnl-1.0.4.tar.bz2
 RUN curl -o /packages/iptables-1.8.10.tar.xz https://www.netfilter.org/projects/iptables/files/iptables-1.8.10.tar.xz
 RUN curl -o /packages/libnftnl-1.2.6.tar.xz https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.2.6.tar.xz
+RUN curl -o /packages/iproute2-5.19.0.tar.gz https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/snapshot/iproute2-5.19.0.tar.gz
 
 # Copy in minimal preset header file to configure net-tools compilation
 COPY config/net-tools.h /packages/

--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 debian:bookworm
 
 RUN mkdir -p /packages
-RUN apt-get update ; apt-get install -y pkg-config make gcc bash curl bison flex
+RUN apt-get update ; apt-get install -y pkg-config make gcc bash curl bison flex xz-utils bzip2
 
 ADD http://smarden.org/runit/runit-2.1.2.tar.gz /packages/runit-2.1.2.tar.gz
 ADD https://downloads.sourceforge.net/project/net-tools/net-tools-2.10.tar.xz /packages/net-tools-2.10.tar.xz

--- a/installer/scripts/compile-runtime-dependencies.sh
+++ b/installer/scripts/compile-runtime-dependencies.sh
@@ -120,13 +120,29 @@ echo "*******************************"
 mkdir -p "$OUTPUT_PATH/iptables-1.8.10"
 cp -r ./iptables "$OUTPUT_PATH/iptables-1.8.10"
 
+cd $PACKAGES_PATH
+echo "************************"
+echo "* extracting iproute2 *"
+echo "************************"
+tar -xvf iproute2-5.19.0.tar.gz
+
+echo "************************"
+echo "* building iproute2 *"
+echo "************************"
+cd iproute2-5.19.0
+unset CFLAGS
+unset LDFLAGS
+./configure
+make CCOPTS="-O2 -pipe -static" LDFLAGS="--static" V=1 # Statically compile ip with verbose logging enabled
+
+
 # Create archive of static binaries and installer
 echo "******************************"
 echo "* creating installer archive *"
 echo "******************************"
 cp "$PACKAGES_PATH/installer.sh" "$OUTPUT_PATH/installer.sh"
 cd $OUTPUT_PATH
-tar -czf runtime-dependencies.tar.gz net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10
+tar -czf runtime-dependencies.tar.gz net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10 iproute2-5.19.0
 
 # Remove binaries outside of the archive 
 echo "*****************************"

--- a/installer/scripts/compile-runtime-dependencies.sh
+++ b/installer/scripts/compile-runtime-dependencies.sh
@@ -125,6 +125,7 @@ echo "************************"
 echo "* extracting iproute2 *"
 echo "************************"
 tar -xvf iproute2-5.19.0.tar.gz
+mkdir -p "$OUTPUT_PATH/iproute2-5.19.0"
 
 echo "************************"
 echo "* building iproute2 *"
@@ -133,7 +134,8 @@ cd iproute2-5.19.0
 unset CFLAGS
 unset LDFLAGS
 ./configure
-make CCOPTS="-O2 -pipe -static" LDFLAGS="--static" V=1 # Statically compile ip with verbose logging enabled
+make CCOPTS="-O2 -pipe -static" LDFLAGS="--static" SUBDIRS="lib ip" V=1 # Statically compile ip with verbose logging enabled
+cp ip/ip "$OUTPUT_PATH/iproute2-5.19.0"
 
 
 # Create archive of static binaries and installer
@@ -148,4 +150,4 @@ tar -czf runtime-dependencies.tar.gz net-tools-2.10 runit-2.1.2 installer.sh ipt
 echo "*****************************"
 echo "* removing unused artifacts *"
 echo "*****************************"
-rm -rf net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10
+rm -rf net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10 iproute2-5.19.0

--- a/installer/scripts/compile-runtime-dependencies.sh
+++ b/installer/scripts/compile-runtime-dependencies.sh
@@ -124,18 +124,18 @@ cd $PACKAGES_PATH
 echo "************************"
 echo "* extracting iproute2 *"
 echo "************************"
-tar -xvf iproute2-5.19.0.tar.gz
-mkdir -p "$OUTPUT_PATH/iproute2-5.19.0"
+tar -xvf iproute2-6.7.0.tar.gz
+mkdir -p "$OUTPUT_PATH/iproute2-6.7.0"
 
 echo "************************"
 echo "* building iproute2 *"
 echo "************************"
-cd iproute2-5.19.0
+cd iproute2-6.7.0
 unset CFLAGS
 unset LDFLAGS
 ./configure
 make CCOPTS="-O2 -pipe -static" LDFLAGS="--static" SUBDIRS="lib ip" V=1 # Statically compile ip with verbose logging enabled
-cp ip/ip "$OUTPUT_PATH/iproute2-5.19.0"
+cp ip/ip "$OUTPUT_PATH/iproute2-6.7.0"
 
 
 # Create archive of static binaries and installer
@@ -144,10 +144,10 @@ echo "* creating installer archive *"
 echo "******************************"
 cp "$PACKAGES_PATH/installer.sh" "$OUTPUT_PATH/installer.sh"
 cd $OUTPUT_PATH
-tar -czf runtime-dependencies.tar.gz net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10 iproute2-5.19.0
+tar -czf runtime-dependencies.tar.gz net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10 iproute2-6.7.0
 
 # Remove binaries outside of the archive 
 echo "*****************************"
 echo "* removing unused artifacts *"
 echo "*****************************"
-rm -rf net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10 iproute2-5.19.0
+rm -rf net-tools-2.10 runit-2.1.2 installer.sh iptables-1.8.10 iproute2-6.7.0

--- a/installer/scripts/installer.sh
+++ b/installer/scripts/installer.sh
@@ -35,4 +35,15 @@ if [ -z "$IPTABLES_PATH" ]; then
   echo "iptables installed successfully"
 fi
 
+IP_PATH=`command -v ip`
+if [ -z "$IP_PATH" ]; then
+  echo "Installing prebuilt ip"
+  IP_TARGET_PATH=/usr/local/bin/ip 
+  install -m 0755 ./iproute2-5.19.0/ip "$IP_TARGET_PATH"
+  IP_PATH_POST_INSTALL=`command -v ip`
+  echo "IP_PATH_POST_INSTALL: $IP_PATH_POST_INSTALL"
+  test "$IP_PATH_POST_INSTALL" = "$IP_TARGET_PATH" || exit 1
+  echo "ip installed successfully"
+fi
+
 exit 0

--- a/installer/scripts/installer.sh
+++ b/installer/scripts/installer.sh
@@ -39,7 +39,7 @@ IP_PATH=`command -v ip`
 if [ -z "$IP_PATH" ]; then
   echo "Installing prebuilt ip"
   IP_TARGET_PATH=/usr/local/bin/ip 
-  install -m 0755 ./iproute2-5.19.0/ip "$IP_TARGET_PATH"
+  install -m 0755 ./iproute2-6.7.0/ip "$IP_TARGET_PATH"
   IP_PATH_POST_INSTALL=`command -v ip`
   echo "IP_PATH_POST_INSTALL: $IP_PATH_POST_INSTALL"
   test "$IP_PATH_POST_INSTALL" = "$IP_TARGET_PATH" || exit 1

--- a/installer/scripts/test-installer.sh
+++ b/installer/scripts/test-installer.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Rudimentary test script to ensure all binaries are available on multiple distros
+
+command -v runit
+runit --help
+
+command -v ifconfig
+ifconfig --help
+
+command -v iptables
+iptables --help
+
+command -v ip
+ip --help

--- a/installer/scripts/test-installer.sh
+++ b/installer/scripts/test-installer.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
 
+set -e
+
 # Rudimentary test script to ensure all binaries are available on multiple distros
 
+# Cannot use runit directly
 command -v runit
-runit --help
 
 command -v ifconfig
-ifconfig --help
+# Run base command (list interfaces)
+ifconfig
 
 command -v iptables
-iptables --help
+iptables -h
 
 command -v ip
-ip --help
+# List available addresses
+ip addr

--- a/installer/test-abyss.Dockerfile
+++ b/installer/test-abyss.Dockerfile
@@ -6,3 +6,7 @@ RUN cd /opt/evervault ; \
  gunzip runtime-dependencies.tar.gz ; \
  tar -xf runtime-dependencies.tar ; \
  sh installer.sh
+
+COPY scripts/test-installer.sh /test-installer.sh
+
+ENTRYPOINT [ "sh", "/test-installer.sh" ]

--- a/installer/test-abyss.Dockerfile
+++ b/installer/test-abyss.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=amd64 ubuntu 
+FROM --platform=amd64 autamus/abyss:latest
 
 RUN mkdir -p /opt/evervault
 COPY output/runtime-dependencies.tar.gz /opt/evervault

--- a/installer/test-alpine.Dockerfile
+++ b/installer/test-alpine.Dockerfile
@@ -6,3 +6,7 @@ RUN cd /opt/evervault ; \
  gunzip runtime-dependencies.tar.gz ; \
  tar -xf runtime-dependencies.tar ; \
  sh installer.sh
+
+COPY scripts/test-installer.sh /test-installer.sh
+
+ENTRYPOINT [ "sh", "/test-installer.sh" ]

--- a/installer/test-alpine.Dockerfile
+++ b/installer/test-alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=amd64 ubuntu 
+FROM --platform=amd64 alpine 
 
 RUN mkdir -p /opt/evervault
 COPY output/runtime-dependencies.tar.gz /opt/evervault

--- a/installer/test.Dockerfile
+++ b/installer/test.Dockerfile
@@ -6,3 +6,7 @@ RUN cd /opt/evervault ; \
  gunzip runtime-dependencies.tar.gz ; \
  tar -xf runtime-dependencies.tar ; \
  sh installer.sh
+
+COPY scripts/test-installer.sh /test-installer.sh
+
+ENTRYPOINT [ "sh", "/test-installer.sh" ]


### PR DESCRIPTION
# Why
We need to include a portable binary for the `ip` command to work across distros as its needed in our new networking implementation.

# How
- Pull iproute2 v6.7.0 into the installer (must be v6 as [any prior version isn't compatible with Musl](https://lore.kernel.org/netdev/20220806082406.216286-1-vincent@systemli.org/T/)).
- Extract iproute2 and perform a static compilation, reducing the compilation to only ip and the required libraries.
- Add testing action to build the installer and run it on a small sample of distros to verify that the binaries can be installed and run (with the exception of runit which exits with a non-zero code when run with any PID other than 1)
