### PR TITLE
Fix AWS credentials for installer release

### DIFF
--- a/.github/workflows/deploy-runtime-installer-production.yml
+++ b/.github/workflows/deploy-runtime-installer-production.yml
@@ -23,6 +23,6 @@ jobs:
         stage: 'production'
         version: ${{ needs.get-version.outputs.version }}
     secrets:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }} 


### PR DESCRIPTION
# Why
The new production workflow was using staging creds

# How
Fix
