### PR TITLE
Get test domain IP on test startup

### DIFF
--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -10,8 +10,6 @@ use shared::server::{get_vsock_client, Listener};
 use shared::utils::pipe_streams;
 use shared::EGRESS_PROXY_PORT;
 use shared::EGRESS_PROXY_VSOCK_PORT;
-#[cfg(not(feature = "enclave"))]
-use shared::TEST_EGRESS_IP;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::os::fd::AsRawFd;
 use std::os::fd::RawFd;
@@ -81,7 +79,8 @@ impl EgressProxy {
     #[cfg(not(feature = "enclave"))]
     fn get_destination(_: RawFd) -> Result<(Ipv4Addr, u16), DNSError> {
         // Hardcode egress IP for docker setup as SO_ORIGINAL_DST is not supported
-        let addr = TEST_EGRESS_IP
+        let addr = std::env::var("TEST_EGRESS_IP")
+            .expect("TEST_EGRESS_IP not found in env")
             .parse::<Ipv4Addr>()
             .expect("Invalid IP address");
         Ok((addr, 443))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - EV_API_KEY_AUTH=${EV_API_KEY_AUTH:?No api key auth set, failing fast}
       - CUSTOMER_PROCESS=${CUSTOMER_PROCESS}
       - AWS_REGION=us-east-1
+      - TEST_EGRESS_IP=${TEST_EGRESS_IP}
   control-plane:
     build:
       dockerfile: control-plane.Dockerfile

--- a/e2e-tests/run-all-feature-tests.sh
+++ b/e2e-tests/run-all-feature-tests.sh
@@ -30,6 +30,8 @@ fi
 # install the node modules for customer process and test script
 cd e2e-tests && npm install && cd ..
 
+export TEST_EGRESS_IP=$(dig +short jsonplaceholder.typicode.com | head -n 1)
+
 # Compile mock crypto api
 if [[ -z "${CI}" ]];
 then

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -21,9 +21,6 @@ pub const ENCLAVE_IP: &str = "172.20.0.7";
 #[cfg(not(feature = "enclave"))]
 pub const PARENT_IP: &str = "172.20.0.8";
 
-#[cfg(not(feature = "enclave"))]
-pub const TEST_EGRESS_IP: &str = "172.64.101.22";
-
 pub mod acme;
 pub mod logging;
 pub mod rpc;


### PR DESCRIPTION
# Why
The test IP was hardcoded

# How
Get IP on test startup and export to env
