### PR TITLE
Add acme stats and improve failure

### DIFF
--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -332,11 +332,11 @@ impl AcmeCertificateRetreiver {
             };
 
             let raw_acme_certificate = self
-                .order_certificate(cert_domains, key.clone(), provider)
+                .order_certificate(cert_domains, key.clone(), provider.clone())
                 .await;
 
             if let Err(e) = raw_acme_certificate {
-                StatsClient::record_cert_order(provider, false);
+                StatsClient::record_cert_order(provider.get_stats_key(), false);
                 log::error!(
                     "[ACME] Error ordering certificate: {:?}. Provider: {:?}",
                     e,
@@ -345,11 +345,13 @@ impl AcmeCertificateRetreiver {
                 certificate_lock.delete().await?;
                 return Err(e);
             } else {
-                StatsClient::record_cert_order(provider, true);
+                StatsClient::record_cert_order(provider.get_stats_key(), true);
             }
 
+            let acme_certificate = raw_acme_certificate?;
+
             let encrypted_raw_certificate =
-                Self::encrypt_certificate(&self.e3_client, &raw_acme_certificate).await?;
+                Self::encrypt_certificate(&self.e3_client, &acme_certificate).await?;
 
             encrypted_raw_certificate
                 .persist(&self.config_client)
@@ -357,9 +359,9 @@ impl AcmeCertificateRetreiver {
 
             certificate_lock.delete().await?;
 
-            let x509s = raw_acme_certificate.to_x509s()?;
+            let x509s = acme_certificate.to_x509s()?;
 
-            Ok(Some(raw_acme_certificate.to_certified_key(x509s, key)?))
+            Ok(Some(acme_certificate.to_certified_key(x509s, key)?))
         } else {
             Ok(None)
         }

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -15,7 +15,8 @@ use tokio_rustls::rustls::{
 use crate::{
     config_client::{ConfigClient, StorageConfigClientInterface},
     e3client::{CryptoRequest, CryptoResponse, E3Api, E3Client},
-    EnclaveContext, stats_client::StatsClient,
+    stats_client::StatsClient,
+    EnclaveContext,
 };
 
 use super::{
@@ -336,7 +337,11 @@ impl AcmeCertificateRetreiver {
 
             if let Err(e) = raw_acme_certificate {
                 StatsClient::record_cert_order(provider, false);
-                log::error!("[ACME] Error ordering certificate: {:?}. Provider: {:?}", e, provider);
+                log::error!(
+                    "[ACME] Error ordering certificate: {:?}. Provider: {:?}",
+                    e,
+                    provider
+                );
                 certificate_lock.delete().await?;
                 return Err(e);
             } else {

--- a/data-plane/src/acme/provider.rs
+++ b/data-plane/src/acme/provider.rs
@@ -25,4 +25,11 @@ impl Provider {
             Provider::ZeroSSL => true,
         }
     }
+
+    pub fn get_stats_key(&self) -> &str {
+        match &self {
+            Self::LetsEncrypt => "acme.letsencrypt",
+            Self::ZeroSSL => "acme.zerossl",
+        }
+    }
 }

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -19,7 +19,6 @@ use tokio_rustls::TlsAcceptor;
 
 use super::inter_ca_retreiver;
 
-use crate::acme;
 #[cfg(feature = "enclave")]
 use crate::acme;
 

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -19,6 +19,7 @@ use tokio_rustls::TlsAcceptor;
 
 use super::inter_ca_retreiver;
 
+use crate::acme;
 #[cfg(feature = "enclave")]
 use crate::acme;
 
@@ -132,11 +133,17 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
 
 #[cfg(feature = "enclave")]
 async fn enclave_trusted_cert() -> Option<CertifiedKey> {
-    let (pub_key, trusted_cert) = acme::get_trusted_cert()
-        .await
-        .expect("Failed to get trusted cert");
-    let _ = TRUSTED_PUB_CERT.set(pub_key);
-    Some(trusted_cert)
+    match acme::get_trusted_cert().await {
+        Ok((pub_key, trusted_cert)) => {
+            let _ = TRUSTED_PUB_CERT.set(pub_key);
+            Some(trusted_cert)
+        }
+        Err(e) => {
+            //Shutdown if we can't get a trusted cert as it's required.
+            log::error!("Failed to get trusted cert for enclave. Shutting down. Cause of error: {e}");
+            std::process::exit(1);
+        }
+    }
 }
 
 #[async_trait]

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -140,7 +140,9 @@ async fn enclave_trusted_cert() -> Option<CertifiedKey> {
         }
         Err(e) => {
             //Shutdown if we can't get a trusted cert as it's required.
-            log::error!("Failed to get trusted cert for enclave. Shutting down. Cause of error: {e}");
+            log::error!(
+                "Failed to get trusted cert for enclave. Shutting down. Cause of error: {e}"
+            );
             std::process::exit(1);
         }
     }

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -36,3 +36,15 @@ macro_rules! publish_count {
         );
     };
 }
+
+#[macro_export]
+macro_rules! publish_count_dynamic_label {
+    ($label:expr, $val:expr, $context:expr) => {
+        statsd_count!(
+          $label,
+          $val,
+          "cage_uuid" => &$context.uuid,
+          "app_uuid" => &$context.app_uuid
+        );
+    };
+}


### PR DESCRIPTION
# Why
Unwraps and metrics can be improved with acme to give us more observability into the acme order process.

# How
Added extra logs
Removed unwrap when cert ordering fails and replace with proper shutdown. 
Started publishing stats on cert provider success or failure.
