### PR TITLE
Fix: Correct logic for reading entire payloads from the incoming connection before passing to user process

### DIFF
--- a/data-plane/src/server/http/parse.rs
+++ b/data-plane/src/server/http/parse.rs
@@ -148,27 +148,30 @@ async fn read_incoming_body_from_stream<T: AsyncRead + Unpin>(
 
 #[cfg(test)]
 mod test {
-  use super::read_incoming_body_from_stream;
-  use hyper;
-  
-  // Test to simulate repeated reads from the accepted connection
-  // Asserts that all bytes are read into the buffer correctly before being passed along as a body
-  #[tokio::test]
-  async fn simulate_large_payload_from_socket() {
-    let content_length = 5;
-    let mut io_mock = tokio_test::io::Builder::new()
-      .read(&[1,2])
-      .read(&[3])
-      .read(&[4,5])
-      .read(&[])
-      .build();
+    use super::read_incoming_body_from_stream;
+    use hyper;
 
-    let test_buf = Vec::with_capacity(5);
+    // Test to simulate repeated reads from the accepted connection
+    // Asserts that all bytes are read into the buffer correctly before being passed along as a body
+    #[tokio::test]
+    async fn simulate_large_payload_from_socket() {
+        let content_length = 5;
+        let mut io_mock = tokio_test::io::Builder::new()
+            .read(&[1, 2])
+            .read(&[3])
+            .read(&[4, 5])
+            .read(&[])
+            .build();
 
-    let result = read_incoming_body_from_stream(content_length, &mut io_mock, test_buf).await;
-    assert!(result.is_ok());
-    let payload = hyper::body::to_bytes(result.unwrap()).await.unwrap().to_vec();
-    assert_eq!(payload.len(), content_length);
-    assert_eq!(&payload, &[1u8,2u8,3u8,4u8,5u8]);
-  }
+        let test_buf = Vec::with_capacity(5);
+
+        let result = read_incoming_body_from_stream(content_length, &mut io_mock, test_buf).await;
+        assert!(result.is_ok());
+        let payload = hyper::body::to_bytes(result.unwrap())
+            .await
+            .unwrap()
+            .to_vec();
+        assert_eq!(payload.len(), content_length);
+        assert_eq!(&payload, &[1u8, 2u8, 3u8, 4u8, 5u8]);
+    }
 }

--- a/data-plane/src/server/http/parse.rs
+++ b/data-plane/src/server/http/parse.rs
@@ -130,16 +130,45 @@ async fn read_incoming_body_from_stream<T: AsyncRead + Unpin>(
     stream: &mut T,
     mut buffer: Vec<u8>,
 ) -> Result<hyper::Body, ParseError> {
+    let mut read_buffer = [0u8; 1024];
     while buffer.len() < content_length {
         let n_bytes_read = tokio::time::timeout(
             std::time::Duration::from_secs(READ_TIMEOUT as u64),
-            stream.read(&mut buffer),
+            stream.read(&mut read_buffer),
         )
         .await
         .map_err(ParseError::from)??;
         if n_bytes_read == 0 {
             return Err(ParseError::UnexpectedEof);
         }
+        buffer.extend_from_slice(&read_buffer[..n_bytes_read]);
     }
     Ok(hyper::Body::from(buffer))
+}
+
+#[cfg(test)]
+mod test {
+  use super::read_incoming_body_from_stream;
+  use hyper;
+  
+  // Test to simulate repeated reads from the accepted connection
+  // Asserts that all bytes are read into the buffer correctly before being passed along as a body
+  #[tokio::test]
+  async fn simulate_large_payload_from_socket() {
+    let content_length = 5;
+    let mut io_mock = tokio_test::io::Builder::new()
+      .read(&[1,2])
+      .read(&[3])
+      .read(&[4,5])
+      .read(&[])
+      .build();
+
+    let test_buf = Vec::with_capacity(5);
+
+    let result = read_incoming_body_from_stream(content_length, &mut io_mock, test_buf).await;
+    assert!(result.is_ok());
+    let payload = hyper::body::to_bytes(result.unwrap()).await.unwrap().to_vec();
+    assert_eq!(payload.len(), content_length);
+    assert_eq!(&payload, &[1u8,2u8,3u8,4u8,5u8]);
+  }
 }


### PR DESCRIPTION
# Why
When large payloads were received in the Enclave, the connection would hang. The vector being passed to the socket read call had no cursor, so its length would not equal the content length.

# How
Use a small preallocated buffer to read the body into and extend the vector from it. Add a test to validate that repeated calls to the socket are performed during the parse loop, and the resulting body is correct.