### PR TITLE
Sync clock enclave clock with host instance

### DIFF
--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -89,14 +89,10 @@ impl EgressProxy {
     #[cfg(feature = "enclave")]
     fn get_destination(fd: RawFd) -> Result<(Ipv4Addr, u16), DNSError> {
         use libc::sockaddr_in;
-        use libc::sockaddr_in6;
         use libc::socklen_t;
         use std::io::Error;
 
-        println!("GETTING DESTIONATION!!!");
-
         let mut addr: sockaddr_in = unsafe { std::mem::zeroed() };
-        let mut addr_6: sockaddr_in6 = unsafe { std::mem::zeroed() };
         let mut len: socklen_t = std::mem::size_of::<sockaddr_in>() as socklen_t;
 
         let response_code = unsafe {
@@ -108,22 +104,11 @@ impl EgressProxy {
                 &mut len as *mut _,
             )
         };
-
         if response_code == -1 {
-            let response_code = unsafe {
-                libc::getsockopt(
-                    fd,
-                    libc::SOL_IPV6,
-                    libc::SO_ORIGINAL_DST,
-                    &mut addr as *mut _ as *mut _,
-                    &mut len as *mut _,
-                )
-            };
             let e = Error::last_os_error();
             Err(e.into())
         } else {
             let ip = Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr));
-            println!("GOT IP!!! {}", ip.to_string());
             let port = u16::from_be(addr.sin_port);
             Ok((ip, port))
         }

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -89,10 +89,14 @@ impl EgressProxy {
     #[cfg(feature = "enclave")]
     fn get_destination(fd: RawFd) -> Result<(Ipv4Addr, u16), DNSError> {
         use libc::sockaddr_in;
+        use libc::sockaddr_in6;
         use libc::socklen_t;
         use std::io::Error;
 
+        println!("GETTING DESTIONATION!!!");
+
         let mut addr: sockaddr_in = unsafe { std::mem::zeroed() };
+        let mut addr_6: sockaddr_in6 = unsafe { std::mem::zeroed() };
         let mut len: socklen_t = std::mem::size_of::<sockaddr_in>() as socklen_t;
 
         let response_code = unsafe {
@@ -106,10 +110,20 @@ impl EgressProxy {
         };
 
         if response_code == -1 {
+            let response_code = unsafe {
+                libc::getsockopt(
+                    fd,
+                    libc::SOL_IPV6,
+                    libc::SO_ORIGINAL_DST,
+                    &mut addr as *mut _ as *mut _,
+                    &mut len as *mut _,
+                )
+            };
             let e = Error::last_os_error();
             Err(e.into())
         } else {
             let ip = Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr));
+            println!("GOT IP!!! {}", ip.to_string());
             let port = u16::from_be(addr.sin_port);
             Ok((ip, port))
         }

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -20,8 +20,8 @@ pub mod error;
 pub mod health;
 pub mod stats;
 pub mod stats_client;
-pub mod utils;
 pub mod time;
+pub mod utils;
 #[cfg(feature = "network_egress")]
 use shared::server::egress::EgressConfig;
 #[cfg(feature = "tls_termination")]

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -21,6 +21,7 @@ pub mod health;
 pub mod stats;
 pub mod stats_client;
 pub mod utils;
+pub mod time;
 #[cfg(feature = "network_egress")]
 use shared::server::egress::EgressConfig;
 #[cfg(feature = "tls_termination")]

--- a/data-plane/src/mocks/config_client_mock.rs
+++ b/data-plane/src/mocks/config_client_mock.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use error::Result;
 use mockall::mock;
+use shared::server::config_server::requests::GetClockSyncResponse;
 use shared::server::config_server::requests::GetObjectResponse;
 
 use crate::{config_client::StorageConfigClientInterface, error};
@@ -14,5 +15,6 @@ mock! {
       async fn get_object(&self, key: String) -> Result<Option<GetObjectResponse>>;
       async fn put_object(&self, key: String, object: String) -> Result<()>;
       async fn delete_object(&self, key: String) -> Result<()>;
+      async fn get_time_from_host(&self) -> Result<GetClockSyncResponse>;
   }
 }

--- a/data-plane/src/time/mod.rs
+++ b/data-plane/src/time/mod.rs
@@ -1,0 +1,78 @@
+use tokio::time::Duration;
+use tokio::time;
+use libc::{clock_gettime, clock_settime, timespec, CLOCK_REALTIME, CLOCK_MONOTONIC_RAW};
+use std::io::Error;
+use std::time::UNIX_EPOCH;
+use std::time::SystemTime;
+
+pub struct TimeSync;
+
+impl TimeSync {
+
+    pub async fn run(interval_duration: Duration) {
+        let mut interval = time::interval(interval_duration);
+        loop {
+            interval.tick().await;
+            println!("This code runs every 5 seconds");
+            Self::sync_time_from_host();
+            Self::get_time();
+        }
+    }
+
+    // fn sync_time_from_host() -> Result<(), String> {
+    //     let new_time: Duration = Duration::new(0, 0);
+    //     let timespec = timespec {
+    //         tv_sec: new_time.as_secs() as i64,
+    //         tv_nsec: new_time.subsec_nanos() as i64,
+    //     };
+ 
+    //     // let timespec = timespec {
+    //     //     tv_sec: 0,
+    //     //     tv_nsec: 0,
+    //     // };
+    
+    //     let result = unsafe { clock_settime(CLOCK_MONOTONIC_RAW, &timespec) };
+    //     if result == 0 {
+    //         Ok(())
+    //     } else {
+    //         println!("THE ERRRRR {:?}", Error::last_os_error());
+    //         Err("Failed to set system time".into())
+    //     }
+    // }
+
+
+fn sync_time_from_host() {
+    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+
+    let ts = timespec {
+        tv_sec: time.as_secs() as i64,
+        tv_nsec: time.subsec_millis() as i64,  
+    };
+
+    let result = unsafe {
+        clock_settime(CLOCK_REALTIME, &ts as *const timespec)
+    };
+
+    if result == 0 {
+        println!("SET TIME SUCCESSFULLY!!!");
+    } else {
+        println!("THE ERRRRR {:?}", Error::last_os_error());
+    }
+}
+
+    fn get_time() {
+        let mut ts = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+    
+        unsafe {
+            if libc::clock_gettime(CLOCK_REALTIME, &mut ts) != 0 {
+                println!("Failed to get time");
+            }
+        }
+
+        println!("DURATION!!!!! {:?}", ts);
+    }
+
+}

--- a/data-plane/src/time/mod.rs
+++ b/data-plane/src/time/mod.rs
@@ -1,78 +1,58 @@
-use tokio::time::Duration;
-use tokio::time;
-use libc::{clock_gettime, clock_settime, timespec, CLOCK_REALTIME, CLOCK_MONOTONIC_RAW};
+use libc::{clock_settime, timespec, CLOCK_REALTIME};
 use std::io::Error;
-use std::time::UNIX_EPOCH;
-use std::time::SystemTime;
+use std::time::SystemTimeError;
+use thiserror::Error;
+use tokio::time;
+use tokio::time::Duration;
 
-pub struct TimeSync;
+use crate::config_client::ConfigClient;
+use crate::config_client::StorageConfigClientInterface;
+use crate::error::Error as DataPlaneError;
 
-impl TimeSync {
+#[derive(Error, Debug)]
+pub enum ClockSyncError {
+    #[error(transparent)]
+    Error(#[from] DataPlaneError),
+    #[error("Clock sync error: {0}")]
+    SyncError(String),
+    #[error("Clock sync error: {0}")]
+    SystemTimeError(#[from] SystemTimeError),
+}
+pub struct ClockSync;
 
+impl ClockSync {
     pub async fn run(interval_duration: Duration) {
         let mut interval = time::interval(interval_duration);
+        let config_client = ConfigClient::new();
         loop {
             interval.tick().await;
-            println!("This code runs every 5 seconds");
-            Self::sync_time_from_host();
-            Self::get_time();
+            match Self::sync_time_from_host(&config_client).await {
+                Ok((s, ms, elapsed)) => log::info!("Enclave time synced with host succesfully - {s}.{ms}s. Request round trip took {elapsed}ms"),
+                Err(e) => log::error!("{e:?}")
+            };
         }
     }
 
-    // fn sync_time_from_host() -> Result<(), String> {
-    //     let new_time: Duration = Duration::new(0, 0);
-    //     let timespec = timespec {
-    //         tv_sec: new_time.as_secs() as i64,
-    //         tv_nsec: new_time.subsec_nanos() as i64,
-    //     };
- 
-    //     // let timespec = timespec {
-    //     //     tv_sec: 0,
-    //     //     tv_nsec: 0,
-    //     // };
-    
-    //     let result = unsafe { clock_settime(CLOCK_MONOTONIC_RAW, &timespec) };
-    //     if result == 0 {
-    //         Ok(())
-    //     } else {
-    //         println!("THE ERRRRR {:?}", Error::last_os_error());
-    //         Err("Failed to set system time".into())
-    //     }
-    // }
+    async fn sync_time_from_host(
+        config_client: &ConfigClient,
+    ) -> Result<(i64, i64, u128), ClockSyncError> {
+        let request_timer = std::time::SystemTime::now();
+        let time = config_client.get_time_from_host().await?;
+        let elapsed = request_timer.elapsed()?.as_millis();
 
-
-fn sync_time_from_host() {
-    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
-    let ts = timespec {
-        tv_sec: time.as_secs() as i64,
-        tv_nsec: time.subsec_millis() as i64,  
-    };
-
-    let result = unsafe {
-        clock_settime(CLOCK_REALTIME, &ts as *const timespec)
-    };
-
-    if result == 0 {
-        println!("SET TIME SUCCESSFULLY!!!");
-    } else {
-        println!("THE ERRRRR {:?}", Error::last_os_error());
-    }
-}
-
-    fn get_time() {
-        let mut ts = timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
+        let ts = timespec {
+            tv_sec: time.seconds,
+            tv_nsec: time.milliseconds,
         };
-    
-        unsafe {
-            if libc::clock_gettime(CLOCK_REALTIME, &mut ts) != 0 {
-                println!("Failed to get time");
-            }
+
+        let result = unsafe { clock_settime(CLOCK_REALTIME, &ts as *const timespec) };
+        if result == 0 {
+            Ok((time.seconds, time.milliseconds, elapsed))
+        } else {
+            Err(ClockSyncError::SyncError(format!(
+                "Could not sync enclave time with host {:?}",
+                Error::last_os_error()
+            )))
         }
-
-        println!("DURATION!!!!! {:?}", ts);
     }
-
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     dns: 127.0.0.1
     cap_add:
       - NET_ADMIN
+    privileged: true      
     ports:
       - "7777:7777"
       - "7779:7779"

--- a/installer/test.Dockerfile
+++ b/installer/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=amd64 debian 
+FROM --platform=amd64 ubuntu 
 
 RUN mkdir -p /opt/evervault
 COPY output/runtime-dependencies.tar.gz /opt/evervault
@@ -9,4 +9,4 @@ RUN cd /opt/evervault ; \
 
 COPY scripts/test-installer.sh /test-installer.sh
 
-# ENTRYPOINT [ "sh", "/test-installer.sh" ]
+ENTRYPOINT [ "sh", "/test-installer.sh" ]

--- a/installer/test.Dockerfile
+++ b/installer/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=amd64 ubuntu 
+FROM --platform=amd64 debian 
 
 RUN mkdir -p /opt/evervault
 COPY output/runtime-dependencies.tar.gz /opt/evervault
@@ -9,4 +9,4 @@ RUN cd /opt/evervault ; \
 
 COPY scripts/test-installer.sh /test-installer.sh
 
-ENTRYPOINT [ "sh", "/test-installer.sh" ]
+# ENTRYPOINT [ "sh", "/test-installer.sh" ]

--- a/shared/src/server/config_server.rs
+++ b/shared/src/server/config_server.rs
@@ -14,6 +14,7 @@ pub mod routes {
         Storage,
         AcmeSign,
         AcmeJWK,
+        Time
     }
 
     impl FromStr for ConfigServerPath {
@@ -27,6 +28,7 @@ pub mod routes {
                 "/storage" => Ok(Self::Storage),
                 "/acme/sign" => Ok(Self::AcmeSign),
                 "/acme/jwk" => Ok(Self::AcmeJWK),
+                "/time" => Ok(Self::Time),
                 _ => Err(ServerError::InvalidPath(input.to_string())),
             }
         }
@@ -41,6 +43,7 @@ pub mod routes {
                 Self::Storage => write!(f, "/storage"),
                 Self::AcmeSign => write!(f, "/acme/sign"),
                 Self::AcmeJWK => write!(f, "/acme/jwk"),
+                Self::Time => write!(f, "/time")
             }
         }
     }
@@ -138,6 +141,12 @@ pub mod requests {
     pub struct Secret {
         pub name: String,
         pub secret: String,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Time {
+        pub seconds: String,
+        pub milliseconds: String,
     }
 
     #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/shared/src/server/config_server.rs
+++ b/shared/src/server/config_server.rs
@@ -14,7 +14,7 @@ pub mod routes {
         Storage,
         AcmeSign,
         AcmeJWK,
-        Time
+        Time,
     }
 
     impl FromStr for ConfigServerPath {
@@ -43,7 +43,7 @@ pub mod routes {
                 Self::Storage => write!(f, "/storage"),
                 Self::AcmeSign => write!(f, "/acme/sign"),
                 Self::AcmeJWK => write!(f, "/acme/jwk"),
-                Self::Time => write!(f, "/time")
+                Self::Time => write!(f, "/time"),
             }
         }
     }
@@ -144,9 +144,15 @@ pub mod requests {
     }
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub struct Time {
-        pub seconds: String,
-        pub milliseconds: String,
+    pub struct GetClockSyncResponse {
+        pub seconds: i64,
+        pub milliseconds: i64,
+    }
+
+    impl GetClockSyncResponse {
+        pub fn into_body(self) -> ServerResult<hyper::Body> {
+            Ok(hyper::Body::from(serde_json::to_vec(&self)?))
+        }
     }
 
     #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
# Why
We have noticed large clock drifts in nitro enclaves, up to 6 seconds in a single week. There is no syncing mechanism out of the box for nitro enclaves so this PR adds a scheduled task to request the host's time and sets the enclave time to the same thing. TBC if this is sufficient

# How
- Request the host time from the control plane periodically (5 mins atm)
- Log the time the request took to the control plane - we may need to account for this
- Set the time with `clock_settime` - its a POSIX compliant sys call so _should't_ cause us issues
