### PR TITLE
Skip clock sync if request took too long

### DIFF
--- a/data-plane/src/time/mod.rs
+++ b/data-plane/src/time/mod.rs
@@ -53,7 +53,7 @@ impl ClockSync {
         let result = unsafe { clock_settime(CLOCK_REALTIME, &ts as *const timespec) };
         if result == 0 {
             log::info!(
-                "Enclave time synced with host succesfully - {}.{}s. Request round trip took {}ns",
+                "Enclave time synced with host successfully - {}.{}s. Request round trip took {}ns",
                 time.seconds,
                 time.milliseconds,
                 elapsed.as_nanos()

--- a/data-plane/src/time/mod.rs
+++ b/data-plane/src/time/mod.rs
@@ -26,20 +26,25 @@ impl ClockSync {
         let config_client = ConfigClient::new();
         loop {
             interval.tick().await;
-            match Self::sync_time_from_host(&config_client).await {
-                Ok((s, ms, elapsed)) => log::info!("Enclave time synced with host succesfully - {s}.{ms}s. Request round trip took {elapsed}ms"),
-                Err(e) => log::error!("{e:?}")
-            };
+            if let Err(e) = Self::sync_time_from_host(&config_client).await {
+                log::error!("{e:?}")
+            }
         }
     }
 
-    async fn sync_time_from_host(
-        config_client: &ConfigClient,
-    ) -> Result<(i64, i64, u128), ClockSyncError> {
+    async fn sync_time_from_host(config_client: &ConfigClient) -> Result<(), ClockSyncError> {
         let request_timer = std::time::SystemTime::now();
         let time = config_client.get_time_from_host().await?;
-        let elapsed = request_timer.elapsed()?.as_millis();
+        let elapsed = request_timer.elapsed()?;
 
+        // On startup the request can take a while so skip the sync till the proxies have stabilized
+        if elapsed.as_millis() > 500 {
+            log::info!(
+                "Skipping clock sync because request took {}ms",
+                elapsed.as_millis()
+            );
+            return Ok(());
+        }
         let ts = timespec {
             tv_sec: time.seconds,
             tv_nsec: time.milliseconds,
@@ -47,7 +52,13 @@ impl ClockSync {
 
         let result = unsafe { clock_settime(CLOCK_REALTIME, &ts as *const timespec) };
         if result == 0 {
-            Ok((time.seconds, time.milliseconds, elapsed))
+            log::info!(
+                "Enclave time synced with host succesfully - {}.{}s. Request round trip took {}ns",
+                time.seconds,
+                time.milliseconds,
+                elapsed.as_nanos()
+            );
+            Ok(())
         } else {
             Err(ClockSyncError::SyncError(format!(
                 "Could not sync enclave time with host {:?}",


### PR DESCRIPTION
# Why
From testing in staging the initial request to sync time takes 22 seconds because the request is made before the proxies stabilise. Every subsequent request is sub 1ms

```
[2024-01-24T11:09:02Z INFO  data_plane::time] Enclave time synced with host successfully - 1706094542.267s. Request round trip took 226018ms
[2024-01-24T11:10:16Z INFO  data_plane::time] Enclave time synced with host successfully - 1706094616.249s. Request round trip took 0ms
[2024-01-24T11:10:18Z INFO  data_plane::time] Enclave time synced with host successfully - 1706094618.152s. Request round trip took 0ms
```

# How
- Skip the clock sync if request takes more than 500ms
- Log the request time in nanoseconds rather than ms so we can see how long it takes when successful