### PR TITLE
Fix endianess for ipv4 addr

### DIFF
--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -115,7 +115,7 @@ impl EgressProxy {
             let e = Error::last_os_error();
             Err(e.into())
         } else {
-            let ip = Ipv4Addr::from(addr.sin_addr.s_addr);
+            let ip = Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr));
             let port = u16::from_be(addr.sin_port);
             Ok((IpAddr::V4(ip), port))
         }


### PR DESCRIPTION
# Why
Needs to be converted to little endian or the ip is incorrect

# How
Convert
