### PR TITLE
[SPE-1129] Update enclave to schedule trusted cert renewnal on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ dependencies = [
  "cadence",
  "cadence-macros",
  "ctrlc",
- "dashmap",
+ "dashmap 4.0.2",
  "dns-message-parser",
  "hyper",
  "lazy_static",
@@ -1307,6 +1307,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1357,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serial_test",
  "sha2",
  "shared",
  "sys-info",
@@ -1696,6 +1710,12 @@ name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -2913,6 +2933,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+dependencies = [
+ "dashmap 5.5.3",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -46,6 +46,8 @@ chrono-tz = { version = "0.8.3" }
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["catch-panic"] }
 libc = "0.2.150"
+serial_test = "3.0.0"
+
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -242,7 +242,7 @@ impl AcmeCertificateRetreiver {
             };
 
             if let Ok(time_till_renewal) = utils::seconds_with_jitter_to_time(days_till_renewal) {
-                log::info!("[ACME] Scheduling renewal for 1 day from now");
+                log::info!("[ACME] Scheduling renewal in {} seconds", days_till_renewal);
                 self_clone.schedule_certificate_renewal(time_till_renewal, key, enclave_context);
             };
         });

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -332,7 +332,7 @@ impl AcmeCertificateRetreiver {
                     last_error = None;
                     break;
                 }
-                delay_in_seconds = delay_in_seconds * i;
+                delay_in_seconds *= i;
                 tokio::time::sleep(Duration::from_secs(delay_in_seconds)).await;
             }
 

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -321,13 +321,13 @@ impl AcmeCertificateRetreiver {
         let attempts = order_lock_maybe
             .as_ref()
             .map_or(0, |lock| lock.number_of_attempts().unwrap_or(0));
-    
+
         if Self::order_lock_exists_and_is_valid(&order_lock_maybe)? {
             log::info!("[ACME] Lock is valid, waiting for Certificate to be created by other instance or waiting for lock to expire");
             // If the lock is valid, do nothing and wait for the certificate to be renewed by another instance or for the lock to expire.
             return Ok(());
         }
-    
+
         match self
             .clone()
             .create_certificate_and_persist_with_lock(key, enclave_context, attempts + 1)
@@ -339,11 +339,13 @@ impl AcmeCertificateRetreiver {
                     .map(|mut store| *store = Some(cert))
                 {
                     log::error!("[ACME] Error updating trusted certificate store: {:?}", e);
-                    Err(AcmeError::General("Error updating trusted certificate store".into()))
+                    Err(AcmeError::General(
+                        "Error updating trusted certificate store".into(),
+                    ))
                 } else {
                     Ok(())
                 }
-            },
+            }
             _ => {
                 log::error!("[ACME] Error renewing certificate. Not updating trusted certificate store: {:?}", e);
                 Err(AcmeError::General("Error renewing certificate".into()))

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -109,7 +109,7 @@ impl RawAcmeCertificate {
             }
 
             let thirty_days_in_seconds = 60 * 60 * 24 * 30;
-            let time_till_expiry_converted = asn1_time_to_system_time(&earliest_expiry)?;
+            let time_till_expiry_converted = asn1_time_to_system_time(earliest_expiry)?;
             let thirty_days_before_expiry =
                 time_till_expiry_converted - Duration::from_secs(thirty_days_in_seconds);
 

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -309,15 +309,19 @@ impl AcmeCertificateRetreiver {
 
             //Retry certificate renewal if it fails
             let retries = 3;
-            for _ in 0..retries {
+            let mut delay_in_seconds = 10;
+            for i in 1..retries {
                 if let Err(e) = self_clone
                     .renew_certificate_and_update_store(key.clone(), &enclave_context)
                     .await
                 {
                     log::error!("[ACME] Error renewing certificate: {:?}", e);
                 } else {
+                    log::info!("[ACME] Certificate renewed successfully.");
                     break;
                 }
+                delay_in_seconds = delay_in_seconds * i;
+                tokio::time::sleep(Duration::from_secs(delay_in_seconds)).await;
             }
         });
     }

--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -347,7 +347,9 @@ impl AcmeCertificateRetreiver {
                 }
             }
             _ => {
-                log::error!("[ACME] Error renewing certificate. Not updating trusted certificate store: {:?}", e);
+                log::error!(
+                    "[ACME] Error renewing certificate. Not updating trusted certificate store"
+                );
                 Err(AcmeError::General("Error renewing certificate".into()))
             }
         }

--- a/data-plane/src/acme/directory.rs
+++ b/data-plane/src/acme/directory.rs
@@ -224,7 +224,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        acme::{mocks::client_mock::MockAcmeClientInterface, provider},
+        acme::mocks::client_mock::MockAcmeClientInterface,
         config_client,
     };
 

--- a/data-plane/src/acme/directory.rs
+++ b/data-plane/src/acme/directory.rs
@@ -223,10 +223,7 @@ impl<T: AcmeClientInterface + std::default::Default> Directory<T> {
 mod tests {
 
     use super::*;
-    use crate::{
-        acme::mocks::client_mock::MockAcmeClientInterface,
-        config_client,
-    };
+    use crate::{acme::mocks::client_mock::MockAcmeClientInterface, config_client};
 
     pub struct TestDirectoryPaths {
         pub new_nonce_url: String,

--- a/data-plane/src/acme/error.rs
+++ b/data-plane/src/acme/error.rs
@@ -51,6 +51,8 @@ pub enum AcmeError {
     RustlsSignError(#[from] tokio_rustls::rustls::sign::SignError),
     #[error("Failed to access context - {0}")]
     ContextError(#[from] ContextError),
+    #[error("System Time Error - {0:?}")]
+    SystemTimeError(#[from] std::time::SystemTimeError),
     #[error("ACME Error {0:?}")]
     AcmeError(#[from] shared::acme::error::AcmeError),
     #[error("ACME Error {0:?}")]

--- a/data-plane/src/acme/mod.rs
+++ b/data-plane/src/acme/mod.rs
@@ -15,6 +15,8 @@ pub mod key;
 pub mod lock;
 pub mod order;
 pub mod provider;
+pub mod raw_cert;
+pub mod utils;
 
 #[cfg(test)]
 pub mod mocks;

--- a/data-plane/src/acme/raw_cert.rs
+++ b/data-plane/src/acme/raw_cert.rs
@@ -1,0 +1,138 @@
+use std::{
+    str::from_utf8,
+    time::{Duration, SystemTime},
+};
+
+use openssl::{
+    asn1::Asn1Time,
+    pkey::{PKey, Private},
+    x509::X509,
+};
+
+use crate::config_client::{ConfigClient, StorageConfigClientInterface};
+
+use super::{error::AcmeError, utils};
+use serde::{Deserialize, Serialize};
+use tokio_rustls::rustls::{
+    sign::{self, CertifiedKey},
+    Certificate, PrivateKey,
+};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RawAcmeCertificate {
+    pub certificate: String,
+}
+
+impl RawAcmeCertificate {
+    pub fn new(certificate: String) -> Self {
+        Self { certificate }
+    }
+
+    pub fn from_x509s(x509s: Vec<X509>) -> Result<RawAcmeCertificate, AcmeError> {
+        let pem_string = Self::convert_to_pemfile(x509s)?;
+
+        Ok(RawAcmeCertificate::new(pem_string))
+    }
+
+    pub fn convert_to_pemfile(certificates: Vec<X509>) -> Result<String, AcmeError> {
+        let mut pem_strings: Vec<String> = Vec::new();
+
+        for x509 in certificates {
+            let pem = x509.to_pem()?;
+            let pem_string = from_utf8(&pem)?.to_string();
+            pem_strings.push(pem_string);
+        }
+
+        let combined_pem: String = pem_strings.join("\n");
+
+        Ok(combined_pem)
+    }
+
+    pub async fn from_storage(
+        config_client: ConfigClient,
+    ) -> Result<Option<RawAcmeCertificate>, AcmeError> {
+        let response_maybe = config_client
+            .get_object(utils::CERTIFICATE_OBJECT_KEY.into())
+            .await?;
+
+        let parsed_response =
+            response_maybe.map(|response| RawAcmeCertificate::new(response.body()));
+
+        Ok(parsed_response)
+    }
+
+    pub fn to_x509s(&self) -> Result<Vec<X509>, AcmeError> {
+        let pem_encoded_certs = self.certificate.as_bytes();
+        let certs = X509::stack_from_pem(pem_encoded_certs)?;
+        Ok(certs)
+    }
+
+    pub fn time_till_renewal_required(&self, x509s: Vec<X509>) -> Result<Duration, AcmeError> {
+        let thirty_days_from_now = Asn1Time::days_from_now(30)?;
+
+        let mut earliest_expiry = None;
+        for cert in x509s.iter() {
+            let cert_expiry = cert.not_after();
+            if earliest_expiry.is_none()
+                || cert_expiry < earliest_expiry.expect("Infallible - Option checked")
+            {
+                earliest_expiry = Some(cert_expiry);
+            }
+        }
+
+        if let Some(earliest_expiry) = earliest_expiry {
+            // If the certificate expires in the next month, renew it immediately.
+            if earliest_expiry < thirty_days_from_now {
+                log::info!("[ACME] Certificate expires in the coming month. Renew it now now");
+                return Ok(Duration::from_secs(0));
+            }
+
+            let time_till_expiry_converted = utils::asn1_time_to_system_time(earliest_expiry)?;
+            let thirty_days_before_expiry =
+                time_till_expiry_converted - Duration::from_secs(utils::THIRTY_DAYS_IN_SECONDS);
+
+            let time_to_renew_with_jitter = utils::get_jittered_time(thirty_days_before_expiry);
+            let time_till_renewal = time_to_renew_with_jitter.duration_since(SystemTime::now())?;
+            return Ok(time_till_renewal);
+        }
+
+        //If failed to get expiry, renew straight away as cert must be corrupted
+        Ok(Duration::from_secs(0))
+    }
+
+    pub fn to_certified_key(
+        &self,
+        x509s: Vec<X509>,
+        private_key: PKey<Private>,
+    ) -> Result<CertifiedKey, AcmeError> {
+        let der_encoded_private_key = private_key.private_key_to_der()?;
+        let ecdsa_private_key = sign::any_ecdsa_type(&PrivateKey(der_encoded_private_key))?;
+
+        let mut pem_certs = Vec::new();
+        for cert in x509s.iter() {
+            let pem_encoded_cert: Vec<u8> = cert.to_pem()?;
+            pem_certs.push(pem_encoded_cert);
+        }
+
+        let combined_pem_encoded_certs: Vec<u8> = pem_certs.concat();
+        let parsed_pems = pem::parse_many(combined_pem_encoded_certs)?;
+
+        let cert_chain: Vec<Certificate> = parsed_pems
+            .into_iter()
+            .map(|p| Certificate(p.contents))
+            .collect();
+        let cert_and_key = CertifiedKey::new(cert_chain, ecdsa_private_key);
+        Ok(cert_and_key)
+    }
+
+    pub async fn persist(&self, config_client: &ConfigClient) -> Result<(), AcmeError> {
+        config_client
+            .put_object(
+                utils::CERTIFICATE_OBJECT_KEY.into(),
+                self.certificate.clone(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/data-plane/src/acme/utils.rs
+++ b/data-plane/src/acme/utils.rs
@@ -1,0 +1,33 @@
+use std::time::{Duration, SystemTime};
+
+use openssl::asn1::Asn1Time;
+use openssl::asn1::Asn1TimeRef;
+use rand::Rng;
+
+use super::error::AcmeError;
+
+pub const CERTIFICATE_LOCK_NAME: &str = "certificate-v1";
+pub const CERTIFICATE_OBJECT_KEY: &str = "certificate-v1.pem";
+pub const ONE_DAY_IN_SECONDS: u64 = 86400;
+pub const THIRTY_DAYS_IN_SECONDS: u64 = ONE_DAY_IN_SECONDS * 30;
+pub const SIXTY_DAYS_IN_SECONDS: u64 = ONE_DAY_IN_SECONDS * 60;
+
+pub(crate) fn asn1_time_to_system_time(time: &Asn1TimeRef) -> Result<SystemTime, AcmeError> {
+    let unix_time = Asn1Time::from_unix(0)?.diff(time)?;
+    Ok(SystemTime::UNIX_EPOCH
+        + Duration::from_secs(unix_time.days as u64 * 86400 + unix_time.secs as u64))
+}
+
+pub(crate) fn get_jittered_time(base_time: SystemTime) -> SystemTime {
+    let mut rng = rand::thread_rng();
+    let jitter_duration = Duration::from_secs(rng.gen_range(1..86400));
+    base_time + jitter_duration
+}
+
+pub(crate) fn seconds_with_jitter_to_time(seconds: u64) -> Result<Duration, AcmeError> {
+    let time = SystemTime::now() + Duration::from_secs(seconds);
+    let jittered_time = get_jittered_time(time);
+    jittered_time
+        .duration_since(SystemTime::now())
+        .map_err(AcmeError::SystemTimeError)
+}

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -112,7 +112,6 @@ impl Environment {
 
     pub fn write_startup_complete_env_vars() -> Result<(), EnvError> {
         let mut file = OpenOptions::new()
-            .write(true)
             .append(true)
             .open("/etc/customer-env")?;
 

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -111,9 +111,7 @@ impl Environment {
     }
 
     pub fn write_startup_complete_env_vars() -> Result<(), EnvError> {
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open("/etc/customer-env")?;
+        let mut file = OpenOptions::new().append(true).open("/etc/customer-env")?;
 
         write!(file, "export EV_INITIALIZED=true")?;
 

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -5,7 +5,9 @@ use std::fs;
 #[cfg(test)]
 pub mod mocks;
 
+#[cfg(feature = "tls_termination")]
 pub mod acme;
+
 pub mod base_tls_client;
 pub mod cache;
 pub mod cert_provisioner_client;

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -141,7 +141,6 @@ async fn start(data_plane_port: u16) {
     }
 }
 
-
 #[allow(unused_variables)]
 async fn start_data_plane(data_plane_port: u16, context: FeatureContext) {
     log::info!("Data plane starting up. Forwarding traffic to {data_plane_port}");

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -141,6 +141,8 @@ async fn start(data_plane_port: u16) {
     }
 }
 
+
+#[allow(unused_variables)]
 async fn start_data_plane(data_plane_port: u16, context: FeatureContext) {
     log::info!("Data plane starting up. Forwarding traffic to {data_plane_port}");
     let server = match get_vsock_server_with_proxy_protocol(ENCLAVE_CONNECT_PORT, Enclave).await {

--- a/data-plane/src/server/mod.rs
+++ b/data-plane/src/server/mod.rs
@@ -7,4 +7,4 @@ pub mod layers;
 #[allow(clippy::module_inception)]
 pub mod server;
 #[cfg(feature = "tls_termination")]
-mod tls;
+pub mod tls;

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -361,6 +361,15 @@ mod tests {
     use openssl::x509::X509;
     use serial_test::serial;
 
+    fn init_context() {
+        let app_uuid = "app_123".to_string();
+        let team_uuid = "team_456".to_string();
+        let enclave_uuid = "enclave_123".to_string();
+        let enclave_name = "my-sick-enclave".to_string();
+        let ctx = EnclaveContext::new(app_uuid, team_uuid, enclave_uuid, enclave_name);
+        EnclaveContext::set(ctx.clone());
+    }
+
     fn parse_x509_from_rustls_certified_key(cert: &CertifiedKey) -> X509 {
         let cert_chain = cert.cert.clone();
         let end_node = cert_chain[0].clone();
@@ -415,6 +424,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_base_cert_used_without_nonce() {
+        init_context();
         let app_uuid = "app_123".to_string();
         let team_uuid = "team_456".to_string();
         let enclave_uuid = "enclave_123".to_string();
@@ -427,6 +437,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_base_cert_using_hyphen_without_nonce() {
+        init_context();
         let app_uuid = "app_123".to_string();
         let team_uuid = "team_456".to_string();
         let enclave_uuid = "enclave_123".to_string();
@@ -439,6 +450,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_base_cert_used_with_nonce() {
+        init_context();
         let app_uuid = "app_123".to_string();
         let team_uuid = "team_456".to_string();
         let enclave_uuid = "enclave_123".to_string();
@@ -480,6 +492,7 @@ mod tests {
     #[cfg(staging)]
     #[test]
     fn test_tld_is_correct_when_compiler_flag_is_set() {
+        init_context();
         let app_uuid = "app_123".to_string();
         let team_uuid = "team_456".to_string();
         let enclave_uuid = "enclave_123".to_string();
@@ -492,6 +505,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_common_name_not_included_for_long_enclave_name() {
+        init_context();
         let app_uuid = "app_123".to_string();
         let team_uuid = "team_456".to_string();
         let enclave_uuid = "enclave_123".to_string();
@@ -528,6 +542,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_common_name_is_included_for_shorter_enclave_name() {
+        init_context();
         let app_uuid = "app_123".to_string();
         let team_uuid = "team_456".to_string();
         let enclave_uuid = "enclave_123".to_string();
@@ -566,6 +581,7 @@ mod tests {
         server_name: Option<String>,
         should_return_trusted_cert: bool,
     ) {
+        init_context();
         let (cert, key) = generate_ca().unwrap();
         let test_trustable_cert = generate_end_cert();
 
@@ -592,6 +608,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_trusted_cert_used_with_trusted_hostname() {
+        init_context();
         let server_name = Some("wicked_enclave.app_123543.cage.evervault.com".to_string());
         test_trusted_cert_with_hostname(server_name, true);
     }
@@ -599,6 +616,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_trusted_cert_used_with_trusted_enclave_hostname() {
+        init_context();
         let server_name = Some("wicked_enclave.app_123543.enclave.evervault.com".to_string());
         test_trusted_cert_with_hostname(server_name, true);
     }
@@ -606,6 +624,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_trusted_cert_used_with_other_hostname() {
+        init_context();
         let server_name = Some("wicked_enclave.app_123543.cages.evervault.com".to_string());
         test_trusted_cert_with_hostname(server_name, false);
     }
@@ -632,12 +651,14 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_checking_for_trusted_hostname_true() {
         let hostname = Some("wicked_enclave.app_123543.enclave.evervault.com");
         assert!(AttestableCertResolver::is_trusted_cert_domain(hostname));
     }
 
     #[test]
+    #[serial]
     fn test_checking_for_trusted_hostname_false() {
         let hostname = Some("wicked_enclave.app_123543.enclaves.evervault.com");
         assert!(!AttestableCertResolver::is_trusted_cert_domain(hostname));

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -558,8 +558,7 @@ mod tests {
 
         write_to_trusted_cert_store(Some(test_trustable_cert.clone()));
 
-        let resolver =
-            AttestableCertResolver::new(cert, key).unwrap();
+        let resolver = AttestableCertResolver::new(cert, key).unwrap();
         let returned_cert = resolver
             .resolve_cert_using_sni(server_name.as_deref())
             .unwrap();

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -92,14 +92,11 @@ pub struct AttestableCertResolver {
     internal_ca: X509,
     internal_pk: PKey<Private>,
     // if we don't receive a nonce, we should return a generic, attestable cert
-    base_cert_container: CertContainer
+    base_cert_container: CertContainer,
 }
 
 impl AttestableCertResolver {
-    pub fn new(
-        internal_ca: X509,
-        internal_pk: PKey<Private>,
-    ) -> ServerResult<Self> {
+    pub fn new(internal_ca: X509, internal_pk: PKey<Private>) -> ServerResult<Self> {
         let enclave_context = EnclaveContext::get()?;
         let hostnames = enclave_context.get_cert_names();
         let (created_at, cert_and_key) = Self::generate_self_signed_cert(
@@ -113,7 +110,7 @@ impl AttestableCertResolver {
             enclave_context,
             internal_ca,
             internal_pk,
-            base_cert_container: CertContainer::new(created_at, cert_and_key)
+            base_cert_container: CertContainer::new(created_at, cert_and_key),
         })
     }
 

--- a/data-plane/src/server/tls/mod.rs
+++ b/data-plane/src/server/tls/mod.rs
@@ -1,5 +1,6 @@
 mod cert_resolver;
 pub(crate) mod inter_ca_retreiver;
 mod tls_server;
+pub mod trusted_cert_container;
 
 pub use tls_server::*;

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -2,6 +2,9 @@ use async_trait::async_trait;
 
 #[cfg(feature = "enclave")]
 use once_cell::sync::OnceCell;
+#[cfg(feature = "enclave")]
+use tokio_rustls::rustls::sign::CertifiedKey;
+
 use openssl::pkey::PKey;
 use openssl::pkey::Private;
 use openssl::x509::X509;

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -92,10 +92,8 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
         //Once intermediate cert and trusted cert retrieved, write cage initialised vars
         Environment::write_startup_complete_env_vars()?;
 
-        let attestable_cert_resolver = super::cert_resolver::AttestableCertResolver::new(
-            ca_cert,
-            ca_private_key
-        )?;
+        let attestable_cert_resolver =
+            super::cert_resolver::AttestableCertResolver::new(ca_cert, ca_private_key)?;
         let mut tls_config =
             Self::get_base_config().with_cert_resolver(Arc::new(attestable_cert_resolver));
         tls_config.alpn_protocols.push(b"http/1.1".to_vec());

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -94,8 +94,7 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
 
         let attestable_cert_resolver = super::cert_resolver::AttestableCertResolver::new(
             ca_cert,
-            ca_private_key,
-            trusted_cert,
+            ca_private_key
         )?;
         let mut tls_config =
             Self::get_base_config().with_cert_resolver(Arc::new(attestable_cert_resolver));

--- a/data-plane/src/server/tls/tls_server.rs
+++ b/data-plane/src/server/tls/tls_server.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tokio_rustls::rustls::server::WantsServerCert;
-use tokio_rustls::rustls::sign::CertifiedKey;
 use tokio_rustls::rustls::ConfigBuilder;
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::server::TlsStream;
@@ -84,10 +83,7 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
         log::debug!("Received intermediate CA from cert provisioner. Using it with TLS Server.");
 
         #[cfg(feature = "enclave")]
-        let trusted_cert: Option<CertifiedKey> = enclave_trusted_cert().await;
-
-        #[cfg(not(feature = "enclave"))] // Don't order trusted certs locally
-        let trusted_cert: Option<CertifiedKey> = None;
+        let _: Option<CertifiedKey> = enclave_trusted_cert().await;
 
         //Once intermediate cert and trusted cert retrieved, write cage initialised vars
         Environment::write_startup_complete_env_vars()?;

--- a/data-plane/src/server/tls/trusted_cert_container.rs
+++ b/data-plane/src/server/tls/trusted_cert_container.rs
@@ -1,10 +1,6 @@
 use once_cell::sync::Lazy;
 use std::sync::{Arc, RwLock};
-#[cfg(not(feature = "enclave"))]
-use std::time::Duration;
-use tokio_rustls::rustls::server::ResolvesServerCert;
-use tokio_rustls::rustls::sign::{self, CertifiedKey};
-use tokio_rustls::rustls::{Certificate, PrivateKey};
+use tokio_rustls::rustls::sign::CertifiedKey;
 
 pub static TRUSTED_CERT_STORE: Lazy<Arc<RwLock<Option<CertifiedKey>>>> =
     Lazy::new(|| Arc::new(RwLock::new(None)));

--- a/data-plane/src/server/tls/trusted_cert_container.rs
+++ b/data-plane/src/server/tls/trusted_cert_container.rs
@@ -1,0 +1,10 @@
+use once_cell::sync::Lazy;
+use std::sync::{Arc, RwLock};
+#[cfg(not(feature = "enclave"))]
+use std::time::Duration;
+use tokio_rustls::rustls::server::ResolvesServerCert;
+use tokio_rustls::rustls::sign::{self, CertifiedKey};
+use tokio_rustls::rustls::{Certificate, PrivateKey};
+
+pub static TRUSTED_CERT_STORE: Lazy<Arc<RwLock<Option<CertifiedKey>>>> =
+    Lazy::new(|| Arc::new(RwLock::new(None)));


### PR DESCRIPTION
# Why
With the new instance refresh flow, we can no longer depend on each enclave being restarted every week for cert renewal. It used to work by checking if the cert needed renewal upon startup. 

# How

*cert renewal*
When the cert is initially ordered, it sets the cert and then schedules a renewal task to run in 60 days + jitter of max 1 days (to account for multiple instances). This means the cert will be renewed if the enclave is never restarted.
If the cert already exists, on startup, the enclave will check the expiry date and set the renewal task to run 30 days before that.

*resolving cert*
Instead of passing the cert down to the resolver, we need to dynamically update the certificate used by the resolver so a RWLock was introduced. I used this over a mutex as the writes should only be on startup and every 60 days, whereas every request requires a read on the cert.
