### PR TITLE
Fix trusted cert fallback

### DIFF
--- a/data-plane/src/acme/cert.rs
+++ b/data-plane/src/acme/cert.rs
@@ -331,7 +331,6 @@ impl AcmeCertificateRetreiver {
                     e,
                     provider
                 );
-                certificate_lock.delete().await?;
                 return Err(e);
             } else {
                 StatsClient::record_cert_order(provider.get_stats_key(), true);
@@ -440,10 +439,10 @@ impl AcmeCertificateRetreiver {
             let challenge_validated = challenge.validate().await?;
 
             challenge_validated
-                .wait_done(Duration::from_secs(5), 5)
+                .wait_done(Duration::from_secs(10), 7)
                 .await?;
 
-            auth.wait_done(Duration::from_secs(5), 5).await?;
+            auth.wait_done(Duration::from_secs(10), 7).await?;
         }
 
         log::info!(


### PR DESCRIPTION
# Why
Deletion of the lock was added in last PR where it shouldn't be. We need to keep the lock on failure to track how many attempts have been made to fall back to ZeroSSL.

# How
Remove line deleting lock and increase duration of polling for order 
