### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,9 +1682,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes 1.1.0",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 resolver = "2"
 members = ["control-plane","data-plane","shared","crates/*"]
 exclude = ["./e2e-tests/mock-crypto"]
+
+[workspace.dependencies]
+openssl = { version = "0.10.60", features = ["vendored"] }

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Evervault <engineering@evervault.com>"]
 [dependencies]
 hyper = { version = "0.14.4", features = ["server","http1","http2","tcp","stream","client"] }
 tokio = { version = "1.24.2", features = ["net", "macros", "rt", "rt-multi-thread", "io-util", "time"] }
-openssl = { version = "0.10.55", features = ["vendored"] }
+openssl = { workspace = true }
 chrono =  { version = "0.4.22", default-features = false, features = ["serde"]}
 aws-nitro-enclaves-nsm-api = "0.2.1"
 aws-nitro-enclaves-cose = "0.5.0"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -27,7 +27,7 @@ tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 sys-info = "0.9.1"
 cadence = "0.29.0"
 httparse = "1.8.0"
-openssl = { version = "0.10.48", features = ["vendored"] }
+openssl = { workspace = true }
 base64 = "0.13.0"
 env_logger = "0.10.0"
 once_cell = { version = "1.19.0", optional = true }


### PR DESCRIPTION
# Why
Dependabot flagged vulns in h2 and openssl.

# How
- Migrate projects to use a shared openssl version
- Bump version of h2
