### PR TITLE
Forward stats to cw and dd on enclave host

### DIFF
--- a/control-plane/src/configuration.rs
+++ b/control-plane/src/configuration.rs
@@ -181,3 +181,10 @@ pub fn get_trusted_cert_base_domains() -> Vec<String> {
 
     enclave_base_domains
 }
+
+pub fn get_external_metrics_enabled() -> bool {
+    match std::env::var("EXTERNAL_METRICS_ENABLED") {
+        Ok(val) => val.to_lowercase() == "true",
+        Err(_) => false,
+    }
+}

--- a/data-plane/src/acme/authorization.rs
+++ b/data-plane/src/acme/authorization.rs
@@ -202,7 +202,7 @@ impl<T: AcmeClientInterface> Authorization<T> {
         let body_str = from_utf8(&resp_bytes)?;
         let mut authorization: Authorization<T> = serde_json::from_str(body_str)?;
 
-        authorization.url = self.url.clone();
+        authorization.url.clone_from(&self.url);
         authorization.account = Some(account.clone());
 
         Ok(authorization)

--- a/data-plane/src/acme/order.rs
+++ b/data-plane/src/acme/order.rs
@@ -200,7 +200,7 @@ impl<T: AcmeClientInterface> Order<T> {
         let mut order: Order<_> = serde_json::from_str(body_str)?;
 
         order.account = Some(account.clone());
-        order.url = self.url.clone();
+        order.url.clone_from(&self.url);
         Ok(order)
     }
 
@@ -246,7 +246,7 @@ impl<T: AcmeClientInterface> Order<T> {
         let mut order: Order<_> = serde_json::from_str(body_str)?;
 
         order.account = Some(account.clone());
-        order.url = self.url.clone();
+        order.url.clone_from(&self.url);
         Ok(order)
     }
 


### PR DESCRIPTION
# Why
We need stats to be forwarded to cloudwatch and other metric agents if enabled by user (i.e. datadog) 

# How
If feature is enabled send to both agents, otherwise send to one
