### PR TITLE
Rename cage to enclave for metrics

### DIFF
--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -167,16 +167,16 @@ describe("Enclave is runnning", () => {
         const stats = JSON.parse(result);
         const keys = Object.keys(stats);
         expect(keys).to.include(
-          "memory.total;cage_uuid=enclave_123;app_uuid=app_12345678"
+          "memory.total;enclave_uuid=enclave_123;app_uuid=app_12345678"
         );
         expect(keys).to.include(
-          "memory.avail;cage_uuid=enclave_123;app_uuid=app_12345678"
+          "memory.avail;enclave_uuid=enclave_123;app_uuid=app_12345678"
         );
         expect(keys).to.include(
-          "cpu.one;cage_uuid=enclave_123;app_uuid=app_12345678"
+          "cpu.one;enclave_uuid=enclave_123;app_uuid=app_12345678"
         );
         expect(keys).to.include(
-          "cpu.cores;cage_uuid=enclave_123;app_uuid=app_12345678"
+          "cpu.cores;enclave_uuid=enclave_123;app_uuid=app_12345678"
         );
       } finally {
         sysClient.destroy();

--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -199,7 +199,7 @@ describe("Enclave is runnning", () => {
         const keys = Object.keys(stats);
 
         expect(keys).to.include(
-          "decrypt.count;cage_uuid=enclave_123;app_uuid=app_12345678"
+          "decrypt.count;enclave_uuid=enclave_123;app_uuid=app_12345678"
         );
       } finally {
         prodClient.destroy();

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -31,7 +31,7 @@ macro_rules! publish_count {
         statsd_count!(
           $label,
           $val,
-          "enlave_uuid" => &$context.uuid,
+          "enclave_uuid" => &$context.uuid,
           "app_uuid" => &$context.app_uuid
         );
     };

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -19,7 +19,7 @@ macro_rules! publish_gauge {
         statsd_gauge!(
           $label,
           $val,
-          "cage_uuid" => &$context.uuid,
+          "enclave_uuid" => &$context.uuid,
           "app_uuid" => &$context.app_uuid
         );
     };
@@ -31,7 +31,7 @@ macro_rules! publish_count {
         statsd_count!(
           $label,
           $val,
-          "cage_uuid" => &$context.uuid,
+          "enlave_uuid" => &$context.uuid,
           "app_uuid" => &$context.app_uuid
         );
     };
@@ -43,7 +43,7 @@ macro_rules! publish_count_dynamic_label {
         statsd_count!(
           $label,
           $val,
-          "cage_uuid" => &$context.uuid,
+          "enclave_uuid" => &$context.uuid,
           "app_uuid" => &$context.app_uuid
         );
     };


### PR DESCRIPTION
# Why
Datadog metrics are live in production but users see `cage_uuid` when querying

# How
Update metric key

<img width="1259" alt="Screenshot 2024-06-25 at 18 31 20" src="https://github.com/evervault/enclaves/assets/92307259/61d645f2-19dc-4c6e-ae60-c123bd352932">

