### PR TITLE
[ETR-2390] Add more logging to sigterm handling

### DIFF
--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -29,7 +29,7 @@ async fn run_ecs_health_check_service(
 ) -> std::result::Result<Response<Body>, ServerError> {
     if is_draining {
         let draining_log =
-            HealthCheckLog::new(HealthCheckStatus::Err, Some("Cage is draining".into()));
+            HealthCheckLog::new(HealthCheckStatus::Err, Some("Enclave is draining".into()));
 
         let combined_log = CombinedHealthCheckLog {
             control_plane: draining_log.clone(),

--- a/control-plane/src/main.rs
+++ b/control-plane/src/main.rs
@@ -240,13 +240,14 @@ fn listen_for_shutdown_signal() {
 
         match rx.recv().await {
             Some(_) => {
+                log::info!("SIGTERM received. Setting Enclave draining flag to true and waiting 55 seconds to terminate Enclave.");
                 if let Err(err) = health::IS_DRAINING.set(true) {
                     log::error!(
                         "Error setting IS_DRAINING to true: {err:?}, continuing to shutdown"
                     );
                 }
 
-                // Wait for 55 seconds before terminating enclave - ECS waits 60 seconds to kill the container
+                // Wait for 55 seconds before terminating enclave - ECS waits 55 seconds to kill the container
                 sleep(Duration::from_millis(55000)).await;
 
                 let output = Command::new("sh")


### PR DESCRIPTION
# Why
It's difficult to tell when an Enclave was sent a sigterm. Should add an info log to always log it.

# How
Add sigterm log and updated "cage" to "enclave" in healthcheck log
