### PR TITLE
Fix: update enclave dns proxy to support multiple dns service providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "control-plane"
-version = "1.0.0-beta"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "aws-config 1.0.1",
@@ -1327,7 +1327,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "data-plane"
-version = "1.0.0-beta"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control-plane"
-version = "1.0.0-beta"
+version = "1.0.0"
 edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 

--- a/control-plane/src/dnsproxy.rs
+++ b/control-plane/src/dnsproxy.rs
@@ -1,4 +1,5 @@
 use crate::error::{Result, ServerError};
+use rand::{seq::IteratorRandom, RngCore};
 use shared::server::egress::check_dns_allowed_for_domain;
 use shared::server::egress::{cache_ip_for_allowlist, EgressDestinations};
 use shared::server::CID::Parent;
@@ -9,46 +10,75 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::UdpSocket;
 
 const DNS_SERVER_OVERRIDE_KEY: &str = "EV_CONTROL_PLANE_DNS_SERVER";
-pub const CLOUDFLARE_DNS_SERVER: IpAddr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
 
-pub fn read_dns_server_ip_from_env_var() -> Option<IpAddr> {
-    std::env::var(DNS_SERVER_OVERRIDE_KEY)
-        .ok()
-        .and_then(|env_var| {
-            env_var
-                .parse()
-                .map_err(|e| {
-                    log::error!("Invalid IP provided to {DNS_SERVER_OVERRIDE_KEY}");
-                    ServerError::InvalidIp(e)
-                })
-                .ok()
-        })
+lazy_static::lazy_static! {
+  pub static ref CLOUDFLARE_DNS_SERVERS: Vec<IpAddr> = vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1))];
+  pub static ref GOOGLE_DNS_SERVERS: Vec<IpAddr> = vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4))];
+  pub static ref OPEN_DNS_SERVERS: Vec<IpAddr> = vec![IpAddr::V4(Ipv4Addr::new(208, 67, 222, 222)), IpAddr::V4(Ipv4Addr::new(208, 67, 220, 220))];
 }
 
-pub struct DnsProxy {
-    dns_server_ip: IpAddr,
+pub fn read_dns_server_ips_from_env_var() -> Option<Vec<IpAddr>> {
+    std::env::var(DNS_SERVER_OVERRIDE_KEY).ok().map(|env_var| {
+        env_var
+            .split(',')
+            .filter_map(|dns_addr| dns_addr.parse::<IpAddr>().ok())
+            .collect()
+    })
 }
 
-impl DnsProxy {
-    pub fn new(target_ip: IpAddr) -> Self {
-        Self {
-            dns_server_ip: target_ip,
+pub struct DnsProxy<R: RngCore + Clone> {
+    dns_server_ips: Vec<IpAddr>,
+    rng: R,
+}
+
+impl<R: RngCore + Clone> std::convert::TryFrom<(Vec<IpAddr>, R)> for DnsProxy<R> {
+    type Error = ServerError;
+
+    fn try_from((dns_server_ips, rng): (Vec<IpAddr>, R)) -> Result<Self> {
+        if dns_server_ips.is_empty() {
+          return Err(ServerError::InvalidDnsConfig);
         }
+        Ok(Self {
+          dns_server_ips,
+          rng
+        })
     }
+}
 
-    pub async fn listen(self) -> Result<()> {
+impl<R: RngCore + Clone> DnsProxy<R> {
+    pub async fn listen(mut self) -> Result<()> {
         let mut server = get_vsock_server(DNS_PROXY_VSOCK_PORT, Parent).await?;
 
         let allowed_domains = shared::server::egress::get_egress_allow_list_from_env();
         loop {
             let domains = allowed_domains.clone();
             match server.accept().await {
-                Ok(stream) => {
+                Ok(mut stream) => {
+                    let selected_dns_services = self
+                        .dns_server_ips
+                        .clone()
+                        .into_iter()
+                        .choose_multiple(&mut self.rng, 2);
+                    log::debug!(
+                        "Selected DNS Services for connection: {:?}",
+                        selected_dns_services
+                    );
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            Self::proxy_dns_connection(self.dns_server_ip, stream, domains).await
-                        {
-                            log::error!("Error proxying dns connection: {e}");
+                        let mut dns_service_iter = selected_dns_services.iter();
+                        let primary_dns_service = dns_service_iter.next().expect("Dns proxy must contain list of at least one service");
+                        let dns_lookup = Self::proxy_dns_connection(primary_dns_service, &mut stream, &domains).await;
+                        match dns_lookup {
+                          Ok(_) => {},
+                          Err(ServerError::EgressError(e)) => log::error!("DNS Connection rejected with egress error: {e}"),
+                          Err(e) => {
+                            log::error!("Error proxying dns connection to primary ({primary_dns_service}): {e}");
+                            if let Some(secondary_service) = dns_service_iter.next() {
+                              log::info!("Retrying dns lookup with secondary provider: {secondary_service}");
+                              if let Err(retry_err) = Self::proxy_dns_connection(secondary_service, &mut stream, &domains).await {
+                                log::error!("Error proxying dns connection to secondary ({secondary_service}): {retry_err}");
+                              }
+                            }
+                          }
                         }
                     });
                 }
@@ -59,17 +89,17 @@ impl DnsProxy {
         Ok(())
     }
 
-    async fn remote_dns_socket(dns_server_ip: IpAddr) -> Result<UdpSocket> {
+    async fn remote_dns_socket(dns_server_ip: &IpAddr) -> Result<UdpSocket> {
         let socket = UdpSocket::bind("0.0.0.0:0").await?;
-        let socket_address = SocketAddr::new(dns_server_ip, 53);
+        let socket_address = SocketAddr::new(*dns_server_ip, 53);
         socket.connect(&socket_address).await?;
         Ok(socket)
     }
 
     async fn proxy_dns_connection<T: AsyncRead + AsyncWrite + Unpin>(
-        target_ip: IpAddr,
-        mut stream: T,
-        allowed_domains: EgressDestinations,
+        target_ip: &IpAddr,
+        stream: &mut T,
+        allowed_domains: &EgressDestinations,
     ) -> Result<()> {
         log::info!("Proxying request to remote");
         let mut request_buffer = [0; 512];
@@ -77,7 +107,7 @@ impl DnsProxy {
 
         let socket = Self::remote_dns_socket(target_ip).await?;
         let mut response_buffer = [0; 512];
-        check_dns_allowed_for_domain(&request_buffer[..packet_size], allowed_domains.clone())?;
+        check_dns_allowed_for_domain(&request_buffer[..packet_size], &allowed_domains)?;
         socket.send(&request_buffer[..packet_size]).await?;
         let (amt, _) = socket.recv_from(&mut response_buffer).await?;
         let response_bytes = &response_buffer[..amt];
@@ -85,13 +115,5 @@ impl DnsProxy {
         stream.write_all(response_bytes).await?;
         stream.flush().await?;
         Ok(())
-    }
-}
-
-impl std::default::Default for DnsProxy {
-    fn default() -> Self {
-        Self {
-            dns_server_ip: std::net::IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
-        }
     }
 }

--- a/control-plane/src/egressproxy.rs
+++ b/control-plane/src/egressproxy.rs
@@ -39,7 +39,7 @@ impl EgressProxy {
             match server.accept().await {
                 Ok(stream) => {
                     tokio::spawn(async move {
-                        if let Err(e) = Self::handle_connection(stream, domains).await {
+                        if let Err(e) = Self::handle_connection(stream, &domains).await {
                             log::error!(
                                 "An error occurred while handling an egress connection - {e:?}"
                             );
@@ -57,7 +57,7 @@ impl EgressProxy {
 
     async fn handle_connection<T: AsyncReadExt + AsyncWriteExt + Unpin>(
         mut external_stream: T,
-        egress_destinations: EgressDestinations,
+        &egress_destinations: EgressDestinations,
     ) -> Result<(u64, u64)> {
         log::debug!("Received request to egress proxy");
         let mut request_buffer = [0; 4096];

--- a/control-plane/src/egressproxy.rs
+++ b/control-plane/src/egressproxy.rs
@@ -57,7 +57,7 @@ impl EgressProxy {
 
     async fn handle_connection<T: AsyncReadExt + AsyncWriteExt + Unpin>(
         mut external_stream: T,
-        &egress_destinations: EgressDestinations,
+        egress_destinations: &EgressDestinations,
     ) -> Result<(u64, u64)> {
         log::debug!("Received request to egress proxy");
         let mut request_buffer = [0; 4096];

--- a/control-plane/src/error.rs
+++ b/control-plane/src/error.rs
@@ -37,7 +37,7 @@ pub enum ServerError {
     #[error("Acme Error - {0}")]
     AcmeError(#[from] shared::acme::error::AcmeError),
     #[error("Invalid DNS Config provided - at least 2 valid DNS Servers must be provided")]
-    InvalidDnsConfig
+    InvalidDnsConfig,
 }
 
 pub type Result<T> = std::result::Result<T, ServerError>;

--- a/control-plane/src/error.rs
+++ b/control-plane/src/error.rs
@@ -36,6 +36,8 @@ pub enum ServerError {
     StorageClientError(#[from] StorageClientError),
     #[error("Acme Error - {0}")]
     AcmeError(#[from] shared::acme::error::AcmeError),
+    #[error("Invalid DNS Config provided - at least 2 valid DNS Servers must be provided")]
+    InvalidDnsConfig
 }
 
 pub type Result<T> = std::result::Result<T, ServerError>;

--- a/control-plane/src/main.rs
+++ b/control-plane/src/main.rs
@@ -114,9 +114,22 @@ async fn main() -> Result<()> {
     {
         listen_for_shutdown_signal();
         let mut health_check_server = health::HealthCheckServer::new().await?;
-        let parsed_ip = control_plane::dnsproxy::read_dns_server_ip_from_env_var()
-            .unwrap_or(control_plane::dnsproxy::CLOUDFLARE_DNS_SERVER);
-        let dns_proxy_server = control_plane::dnsproxy::DnsProxy::new(parsed_ip);
+        let parsed_ip = control_plane::dnsproxy::read_dns_server_ips_from_env_var().unwrap_or(
+            [
+                control_plane::dnsproxy::CLOUDFLARE_DNS_SERVERS.as_slice(),
+                control_plane::dnsproxy::GOOGLE_DNS_SERVERS.as_slice(),
+            ]
+            .concat(),
+        );
+
+        let dns_proxy_server =
+            match control_plane::dnsproxy::DnsProxy::try_from((parsed_ip, rand::thread_rng())) {
+                Ok(proxy_server) => proxy_server,
+                Err(e) => {
+                    log::error!("Failed to create DNS Proxy server - {e}");
+                    return Err(e);
+                }
+            };
         let (
             tcp_result,
             dns_result,

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-plane"
-version = "1.0.0-beta"
+version = "1.0.0"
 edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -59,7 +59,7 @@ impl EgressProxy {
 
         let fd = external_stream.as_raw_fd();
         let (ip, port) = Self::get_destination(fd)?;
-        check_ip_allow_list(ip.to_string(), allowed_domains.clone())?;
+        check_ip_allow_list(ip.to_string(), &allowed_domains)?;
 
         let external_request = ExternalRequest {
             ip,

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -169,7 +169,7 @@ mod tests {
             ips: vec![],
         };
         assert_eq!(
-            check_domain_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
+            check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).unwrap(),
             ()
         );
     }
@@ -182,7 +182,7 @@ mod tests {
             ips: vec![],
         };
         assert_eq!(
-            check_domain_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
+            check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).unwrap(),
             ()
         );
     }
@@ -195,7 +195,7 @@ mod tests {
             ips: vec![],
         };
         assert_eq!(
-            check_domain_allow_list("app.evervault.com".to_string(), egress_domains).unwrap(),
+            check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).unwrap(),
             ()
         );
     }
@@ -207,7 +207,7 @@ mod tests {
             allow_all: false,
             ips: vec![],
         };
-        let result = check_domain_allow_list("google.com".to_string(), egress_domains);
+        let result = check_domain_allow_list("google.com".to_string(), &egress_domains);
         assert!(matches!(result, Err(EgressDomainNotAllowed(_))));
     }
 
@@ -219,7 +219,7 @@ mod tests {
             allow_all: false,
             ips: vec!["2.2.2.2".to_string()],
         };
-        let result = check_ip_allow_list("1.1.1.1".to_string(), egress_domains);
+        let result = check_ip_allow_list("1.1.1.1".to_string(), &egress_domains);
         assert!(matches!(result, Err(EgressIpNotAllowed(_))));
     }
 }

--- a/data-plane/src/dns/enclavedns.rs
+++ b/data-plane/src/dns/enclavedns.rs
@@ -128,7 +128,7 @@ impl EnclaveDnsDriver {
         allowed_destinations: EgressDestinations,
     ) -> Result<Bytes, DNSError> {
         // Check domain is allowed before proxying lookup
-        check_dns_allowed_for_domain(&dns_packet.clone(), allowed_destinations)?;
+        check_dns_allowed_for_domain(&dns_packet.clone(), &allowed_destinations)?;
         // Attempt DNS lookup wth a timeout, flatten timeout errors into a DNS Error
         let dns_response =
             timeout(request_upper_bound, Self::forward_dns_lookup(dns_packet)).await??;

--- a/shared/src/acme/jws.rs
+++ b/shared/src/acme/jws.rs
@@ -291,7 +291,7 @@ mod tests {
         let s = BigNum::from_slice(&signature_bytes[32..]).unwrap();
         let ecdsa_sig = EcdsaSig::from_private_components(r, s).unwrap();
 
-        let mut verifier = openssl::sign::Verifier::new(MessageDigest::sha256(), &ec).unwrap();
+        let verifier = openssl::sign::Verifier::new(MessageDigest::sha256(), &ec).unwrap();
 
         let valid = verifier.verify(&ecdsa_sig.to_der().unwrap()).unwrap();
         assert!(valid == false);

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -110,7 +110,7 @@ fn cache_ip(ip: String, answer: &dns_parser::ResourceRecord<'_>) -> Result<(), E
 
 pub fn check_ip_allow_list(
     ip: String,
-    allowed_destinations: EgressDestinations,
+    allowed_destinations: &EgressDestinations,
 ) -> Result<(), EgressError> {
     if allowed_destinations.allow_all
         || allowed_destinations.ips.contains(&ip)

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -224,7 +224,7 @@ mod tests {
             allow_all: false,
             ips: vec![],
         };
-        let result = check_domain_allow_list("invalid.domain.com".to_string(), destinations);
+        let result = check_domain_allow_list("invalid.domain.com".to_string(), &destinations);
         assert!(matches!(result, Err(EgressDomainNotAllowed(_))));
     }
 
@@ -235,7 +235,7 @@ mod tests {
             allow_all: false,
             ips: vec!["2.2.2.2".to_string()],
         };
-        let result = check_ip_allow_list("1.1.1.1".to_string(), destinations);
+        let result = check_ip_allow_list("1.1.1.1".to_string(), &destinations);
         assert!(matches!(result, Err(EgressIpNotAllowed(_))));
     }
 
@@ -246,7 +246,7 @@ mod tests {
             allow_all: false,
             ips: vec!["1.1.1.1".to_string()],
         };
-        let result = check_ip_allow_list("1.1.1.1".to_string(), destinations);
+        let result = check_ip_allow_list("1.1.1.1".to_string(), &destinations);
         assert!(result.is_ok());
     }
 
@@ -257,7 +257,7 @@ mod tests {
             allow_all: true,
             ips: vec![],
         };
-        let result = check_ip_allow_list("1.1.1.1".to_string(), destinations);
+        let result = check_ip_allow_list("1.1.1.1".to_string(), &destinations);
         assert!(result.is_ok());
     }
 
@@ -268,7 +268,7 @@ mod tests {
             allow_all: true,
             ips: vec!["1.1.1.1".to_string()],
         };
-        let result = check_domain_allow_list("a.domain.com".to_string(), destinations);
+        let result = check_domain_allow_list("a.domain.com".to_string(), &destinations);
         assert!(result.is_ok());
     }
 }

--- a/shared/src/server/egress.rs
+++ b/shared/src/server/egress.rs
@@ -57,7 +57,7 @@ pub fn get_egress_allow_list(domain_str: String) -> EgressDestinations {
 
 pub fn check_domain_allow_list(
     domain: String,
-    allowed_destinations: EgressDestinations,
+    allowed_destinations: &EgressDestinations,
 ) -> Result<(), EgressError> {
     let valid_wildcard = allowed_destinations
         .wildcard
@@ -75,13 +75,13 @@ pub fn check_domain_allow_list(
 
 pub fn check_dns_allowed_for_domain(
     packet: &[u8],
-    destinations: EgressDestinations,
+    destinations: &EgressDestinations,
 ) -> Result<(), EgressError> {
     let packet = dns_parser::Packet::parse(packet)?;
     packet
         .questions
         .iter()
-        .try_for_each(|q| check_domain_allow_list(q.qname.to_string(), destinations.clone()))
+        .try_for_each(|q| check_domain_allow_list(q.qname.to_string(), destinations))
 }
 
 pub fn cache_ip_for_allowlist(packet: &[u8]) -> Result<(), EgressError> {


### PR DESCRIPTION
# Why
Public internet egress currently relies on a single DNS Service provider. Extending this to use several providers with retry logic should remove the DNS Provider as a potential single point of failure.

# How
- Update DNS proxy logic to expect a list of DNS Service IPs
- Randomly select 2 ips from the list for each connection, treating the first entry as the primary, and the second entry as secondary/fallback
- If the first DNS Provider fails for some reason (excl. the allow list being violated), then the dns request is retried against the secondary