### PR TITLE
Restore beta tag suffix to crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "control-plane"
-version = "1.0.0"
+version = "1.0.0-beta"
 dependencies = [
  "async-trait",
  "aws-config 1.0.1",
@@ -1327,7 +1327,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "data-plane"
-version = "1.0.0"
+version = "1.0.0-beta"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control-plane"
-version = "1.0.0"
+version = "1.0.0-beta"
 edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-plane"
-version = "1.0.0"
+version = "1.0.0-beta"
 edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 


### PR DESCRIPTION
# Why
The beta suffix is required to support testing preview images.

# How
Restore beta suffix.