### PR TITLE
chore: Update control plane dns proxy to attempt dns lookup against all services until one resolves

### DIFF
--- a/control-plane/src/main.rs
+++ b/control-plane/src/main.rs
@@ -122,14 +122,7 @@ async fn main() -> Result<()> {
             .concat(),
         );
 
-        let dns_proxy_server =
-            match control_plane::dnsproxy::DnsProxy::try_from((parsed_ip, rand::thread_rng())) {
-                Ok(proxy_server) => proxy_server,
-                Err(e) => {
-                    log::error!("Failed to create DNS Proxy server - {e}");
-                    return Err(e);
-                }
-            };
+        let dns_proxy_server = control_plane::dnsproxy::DnsProxy::new(parsed_ip);
         let (
             tcp_result,
             dns_result,

--- a/data-plane/src/dns/enclavedns.rs
+++ b/data-plane/src/dns/enclavedns.rs
@@ -30,7 +30,7 @@ impl EnclaveDnsProxy {
 
         let dns_driver_socket = shared_socket.clone();
 
-        let dns_request_upper_bound = std::time::Duration::from_secs(3);
+        let dns_request_upper_bound = std::time::Duration::from_secs(10);
         let dns_driver = EnclaveDnsDriver::new(
             dns_driver_socket,
             dns_lookup_receiver,


### PR DESCRIPTION
# Why
DNS Proxy running on the host needs to attempt connections against all hosts to make egress as reliable as possible.

# How
Update proxy logic to iterate over all dns services and only exit when one resolves, or all have been attempted.
