### PR TITLE
Interleave dns providers

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - name: Parse semver from cargo.toml
         id: get-version
         run: |

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - name: Parse semver from cargo.toml
         id: get-version
         run: |

--- a/.github/workflows/test-control-plane.yml
+++ b/.github/workflows/test-control-plane.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test-data-plane.yml
+++ b/.github/workflows/test-data-plane.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"

--- a/.github/workflows/test-shared-lib.yml
+++ b/.github/workflows/test-shared-lib.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "vsock-proxy"
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "vsock-proxy"
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - name: Compile proxy
         run: cargo build -p vsock-proxy --release
       - name: Upload proxy
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
       - name: Publish vsock-proxy
         run: cargo publish -p vsock-proxy
         env:

--- a/control-plane/src/dnsproxy.rs
+++ b/control-plane/src/dnsproxy.rs
@@ -37,7 +37,7 @@ pub struct DnsProxy {
 impl std::default::Default for DnsProxy {
     fn default() -> Self {
         Self {
-            dns_server_ips: DNS_SERVERS.clone()
+            dns_server_ips: DNS_SERVERS.clone(),
         }
     }
 }

--- a/control-plane/src/dnsproxy.rs
+++ b/control-plane/src/dnsproxy.rs
@@ -11,9 +11,14 @@ use tokio::net::UdpSocket;
 const DNS_SERVER_OVERRIDE_KEY: &str = "EV_CONTROL_PLANE_DNS_SERVER";
 
 lazy_static::lazy_static! {
-  pub static ref CLOUDFLARE_DNS_SERVERS: Vec<IpAddr> = vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1))];
-  pub static ref GOOGLE_DNS_SERVERS: Vec<IpAddr> = vec![IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4))];
-  pub static ref OPEN_DNS_SERVERS: Vec<IpAddr> = vec![IpAddr::V4(Ipv4Addr::new(208, 67, 222, 222)), IpAddr::V4(Ipv4Addr::new(208, 67, 220, 220))];
+  pub static ref DNS_SERVERS: Vec<IpAddr> = vec![
+    IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),        // Cloudflare Primary
+    IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),        // Google Primary
+    IpAddr::V4(Ipv4Addr::new(208, 67, 222, 222)), // OpenDNS Primary
+    IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1)),        // Cloudflare Secondary
+    IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4)),        // Google Secondary
+    IpAddr::V4(Ipv4Addr::new(208, 67, 220, 220))  // OpenDNS Secondary
+  ];
 }
 
 pub fn read_dns_server_ips_from_env_var() -> Option<Vec<IpAddr>> {

--- a/control-plane/src/dnsproxy.rs
+++ b/control-plane/src/dnsproxy.rs
@@ -37,11 +37,7 @@ pub struct DnsProxy {
 impl std::default::Default for DnsProxy {
     fn default() -> Self {
         Self {
-            dns_server_ips: [
-                CLOUDFLARE_DNS_SERVERS.as_slice(),
-                GOOGLE_DNS_SERVERS.as_slice(),
-            ]
-            .concat(),
+            dns_server_ips: DNS_SERVERS.clone()
         }
     }
 }

--- a/control-plane/src/main.rs
+++ b/control-plane/src/main.rs
@@ -114,13 +114,8 @@ async fn main() -> Result<()> {
     {
         listen_for_shutdown_signal();
         let mut health_check_server = health::HealthCheckServer::new().await?;
-        let parsed_ip = control_plane::dnsproxy::read_dns_server_ips_from_env_var().unwrap_or(
-            [
-                control_plane::dnsproxy::CLOUDFLARE_DNS_SERVERS.as_slice(),
-                control_plane::dnsproxy::GOOGLE_DNS_SERVERS.as_slice(),
-            ]
-            .concat(),
-        );
+        let parsed_ip = control_plane::dnsproxy::read_dns_server_ips_from_env_var()
+            .unwrap_or_else(|| control_plane::dnsproxy::DNS_SERVERS.clone());
 
         let dns_proxy_server = control_plane::dnsproxy::DnsProxy::new(parsed_ip);
         let (

--- a/data-plane/src/dns/enclavedns.rs
+++ b/data-plane/src/dns/enclavedns.rs
@@ -46,16 +46,17 @@ impl EnclaveDnsProxy {
 
         loop {
             let mut buffer = [0; 512];
-            let (amt, src) = shared_socket.recv_from(&mut buffer).await?;
-            let buf = Bytes::copy_from_slice(&buffer[..amt]);
-            let dispatch_result =
-                timeout(dns_dispatch_timeout, dns_lookup_sender.send((buf, src))).await;
+            if let Ok((amt, src)) = shared_socket.recv_from(&mut buffer).await {
+                let buf = Bytes::copy_from_slice(&buffer[..amt]);
+                let dispatch_result =
+                    timeout(dns_dispatch_timeout, dns_lookup_sender.send((buf, src))).await;
 
-            match dispatch_result {
-                Ok(Err(e)) => log::error!("Error dispatching DNS request: {e:?}"),
-                Err(e) => log::error!("Timeout dispatching DNS request: {e:?}"),
-                _ => {}
-            };
+                match dispatch_result {
+                    Ok(Err(e)) => log::error!("Error dispatching DNS request: {e:?}"),
+                    Err(e) => log::error!("Timeout dispatching DNS request: {e:?}"),
+                    _ => {}
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
# Why
We're updating the Enclave DNS providers to reduce the risk of single point of failure. To make this more robust, the providers are being interleaved so requests will be retried against alternate networks.

# How
Update the list of dns providers to be a singleton containing all of the providers primaries followed by secondaries. 