### PR TITLE
Override default toolchain in enclaves ci

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           toolchain: 1.79.0
           components: rustfmt
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"

--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           toolchain: 1.79.0
           components: rustfmt
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"
@@ -38,6 +39,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - name: Parse semver from cargo.toml
         id: get-version
         run: |

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - name: Parse semver from cargo.toml
         id: get-version
         run: |

--- a/.github/workflows/test-control-plane.yml
+++ b/.github/workflows/test-control-plane.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           toolchain: 1.79.0
           components: rustfmt
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"

--- a/.github/workflows/test-data-plane.yml
+++ b/.github/workflows/test-data-plane.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"
@@ -50,6 +51,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"

--- a/.github/workflows/test-shared-lib.yml
+++ b/.github/workflows/test-shared-lib.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "standard-cache"

--- a/.github/workflows/vsock-proxy.yml
+++ b/.github/workflows/vsock-proxy.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "vsock-proxy"
@@ -38,6 +39,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "vsock-proxy"
@@ -53,6 +55,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - name: Compile proxy
         run: cargo build -p vsock-proxy --release
       - name: Upload proxy
@@ -70,6 +73,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.79.0
+          override: true
       - name: Publish vsock-proxy
         run: cargo publish -p vsock-proxy
         env:


### PR DESCRIPTION
# Why
CI is failing as the default toolchain was upgraded in Github Actions

# How
Set override true to avoid compilation issues with time.
