### PR TITLE
Remove failing deprecated clippy action

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ target
 e2e-tests/node_modules
 e2e-tests/customer-process/node_modules
 data-plane/*.pem
-.cargo
 e2e-tests/sample-ca
 e2e-tests/testing-certs/*
 e2e-tests/mtls-testing-certs/ca/*


### PR DESCRIPTION
# Why
This is causing actions to fail on the `vsock-proxy` crate.

# How
Remove
