### PR TITLE
Introduce versioning to data-plane health checks

### DIFF
--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -57,11 +57,11 @@ async fn run_ecs_health_check_service(
     };
 
     let data_plane_status = match &data_plane {
-        HealthCheckVersion::V0(log) => log.status_code(),
-        HealthCheckVersion::V1(log) => log.status_code(),
+        HealthCheckVersion::V0(log) | HealthCheckVersion::V1(log) => log,
     };
 
-    let status_to_return = std::cmp::max(control_plane.status_code(), data_plane_status);
+    let status_to_return =
+        std::cmp::max(control_plane.status_code(), data_plane_status.status_code());
 
     let combined_log = CombinedHealthCheckLog {
         control_plane,
@@ -173,8 +173,7 @@ mod health_check_tests {
         let health_check_log = response_to_health_check_log(response).await;
 
         let dp_status = match health_check_log.data_plane {
-            HealthCheckVersion::V0(log) => log.status,
-            HealthCheckVersion::V1(log) => log.status,
+            HealthCheckVersion::V0(log) | HealthCheckVersion::V1(log) => log.status,
         };
 
         assert!(matches!(dp_status, HealthCheckStatus::Err));
@@ -189,8 +188,7 @@ mod health_check_tests {
         let health_check_log = response_to_health_check_log(response).await;
 
         let dp_status = match health_check_log.data_plane {
-            HealthCheckVersion::V0(log) => log.status,
-            HealthCheckVersion::V1(log) => log.status,
+            HealthCheckVersion::V0(log) | HealthCheckVersion::V1(log) => log.status,
         };
 
         assert!(matches!(dp_status, HealthCheckStatus::Ignored));
@@ -206,8 +204,7 @@ mod health_check_tests {
         let health_check_log = response_to_health_check_log(response).await;
 
         let dp_status = match health_check_log.data_plane {
-            HealthCheckVersion::V0(log) => log.status,
-            HealthCheckVersion::V1(log) => log.status,
+            HealthCheckVersion::V0(log) | HealthCheckVersion::V1(log) => log.status,
         };
 
         assert!(matches!(dp_status, HealthCheckStatus::Err));

--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -53,7 +53,13 @@ async fn run_ecs_health_check_service(
     let data_plane = if skip_deep_healthcheck {
         HealthCheckVersion::V1(HealthCheckLog::new(HealthCheckStatus::Ignored, None))
     } else {
-        health_check_data_plane().await?
+        match health_check_data_plane().await {
+            Ok(v) => v,
+            Err(e) => HealthCheckVersion::V1(HealthCheckLog::new(
+                HealthCheckStatus::Err,
+                Some(e.to_string()),
+            )),
+        }
     };
 
     let data_plane_status = match &data_plane {

--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -1,8 +1,9 @@
 use crate::enclave_connection::get_connection_to_enclave;
 use crate::error::ServerError;
+use axum::http::HeaderValue;
 use hyper::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
-use shared::server::health::{HealthCheckLog, HealthCheckStatus};
+use shared::server::health::{HealthCheckLog, HealthCheckStatus, HealthCheckVersion};
 use shared::server::{error::ServerResult, tcp::TcpServer, Listener};
 use shared::{env_var_present_and_true, ENCLAVE_HEALTH_CHECK_PORT};
 use std::net::SocketAddr;
@@ -20,7 +21,7 @@ pub struct HealthCheckServer {
 #[serde(rename_all = "camelCase")]
 struct CombinedHealthCheckLog {
     control_plane: HealthCheckLog,
-    data_plane: HealthCheckLog,
+    data_plane: HealthCheckVersion,
 }
 
 async fn run_ecs_health_check_service(
@@ -33,7 +34,7 @@ async fn run_ecs_health_check_service(
 
         let combined_log = CombinedHealthCheckLog {
             control_plane: draining_log.clone(),
-            data_plane: draining_log,
+            data_plane: HealthCheckVersion::V1(draining_log),
         };
 
         let combined_log_json = serde_json::to_string(&combined_log)?;
@@ -50,15 +51,17 @@ async fn run_ecs_health_check_service(
     );
 
     let data_plane = if skip_deep_healthcheck {
-        HealthCheckLog::new(HealthCheckStatus::Ignored, None)
+        HealthCheckVersion::V1(HealthCheckLog::new(HealthCheckStatus::Ignored, None))
     } else {
-        health_check_data_plane().await
+        health_check_data_plane().await?
     };
-    let status_to_return = [control_plane.status.clone(), data_plane.status.clone()]
-        .iter()
-        .max()
-        .unwrap()
-        .clone();
+
+    let data_plane_status = match &data_plane {
+        HealthCheckVersion::V0(log) => log.status_code(),
+        HealthCheckVersion::V1(log) => log.status_code(),
+    };
+
+    let status_to_return = std::cmp::max(control_plane.status_code(), data_plane_status);
 
     let combined_log = CombinedHealthCheckLog {
         control_plane,
@@ -67,38 +70,41 @@ async fn run_ecs_health_check_service(
     let combined_log_json = serde_json::to_string(&combined_log).unwrap();
 
     Response::builder()
-        .status(status_to_return.status_code())
+        .status(status_to_return)
         .header("Content-Type", "application/json")
         .body(Body::from(combined_log_json))
         .map_err(ServerError::from)
 }
 
-macro_rules! unwrap_or_err {
-    ($result:expr) => {
-        match $result {
-            Ok(ok) => ok,
-            Err(error) => {
-                return HealthCheckLog::new(HealthCheckStatus::Err, Some(error.to_string()))
-            }
-        }
-    };
-}
+async fn health_check_data_plane() -> Result<HealthCheckVersion, ServerError> {
+    let stream = get_connection_to_enclave(ENCLAVE_HEALTH_CHECK_PORT).await?;
 
-async fn health_check_data_plane() -> HealthCheckLog {
-    let stream = unwrap_or_err!(get_connection_to_enclave(ENCLAVE_HEALTH_CHECK_PORT).await);
-    let (mut sender, connection) = unwrap_or_err!(hyper::client::conn::handshake(stream).await);
+    let (mut sender, connection) = hyper::client::conn::handshake(stream).await?;
+
     tokio::spawn(connection);
     let request = Request::builder()
         .method("GET")
         .header("User-Agent", "CageHealthChecker/0.0")
         .body(Body::empty())
         .expect("Cannot fail");
-    let response = unwrap_or_err!(sender.send_request(request).await);
-    unwrap_or_err!(serde_json::from_slice(
-        &hyper::body::to_bytes(response.into_parts().1)
-            .await
-            .unwrap()[..]
-    ))
+
+    let response = sender.send_request(request).await?;
+    let (parts, response) = response.into_parts();
+
+    let content_type = parts
+        .headers
+        .get("Content-Type")
+        .map(HeaderValue::to_str)
+        .and_then(Result::ok);
+
+    let bytes = &hyper::body::to_bytes(response).await?;
+
+    Ok(match content_type {
+        Some("application/json;version=1") => {
+            HealthCheckVersion::V1(serde_json::from_slice::<HealthCheckLog>(bytes)?)
+        }
+        _ => HealthCheckVersion::V0(serde_json::from_slice::<HealthCheckLog>(bytes)?),
+    })
 }
 
 impl HealthCheckServer {
@@ -165,10 +171,13 @@ mod health_check_tests {
         assert_eq!(response.status(), 500);
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
-        assert!(matches!(
-            health_check_log.data_plane.status,
-            HealthCheckStatus::Err
-        ));
+
+        let dp_status = match health_check_log.data_plane {
+            HealthCheckVersion::V0(log) => log.status,
+            HealthCheckVersion::V1(log) => log.status,
+        };
+
+        assert!(matches!(dp_status, HealthCheckStatus::Err));
     }
 
     #[tokio::test]
@@ -178,10 +187,13 @@ mod health_check_tests {
         assert_eq!(response.status(), 200);
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
-        assert!(matches!(
-            health_check_log.data_plane.status,
-            HealthCheckStatus::Ignored
-        ));
+
+        let dp_status = match health_check_log.data_plane {
+            HealthCheckVersion::V0(log) => log.status,
+            HealthCheckVersion::V1(log) => log.status,
+        };
+
+        assert!(matches!(dp_status, HealthCheckStatus::Ignored));
     }
 
     #[tokio::test]
@@ -192,10 +204,13 @@ mod health_check_tests {
         assert_eq!(response.status(), 500);
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
-        assert!(matches!(
-            health_check_log.data_plane.status,
-            HealthCheckStatus::Err
-        ));
+
+        let dp_status = match health_check_log.data_plane {
+            HealthCheckVersion::V0(log) => log.status,
+            HealthCheckVersion::V1(log) => log.status,
+        };
+
+        assert!(matches!(dp_status, HealthCheckStatus::Err));
         assert!(matches!(
             health_check_log.control_plane.status,
             HealthCheckStatus::Err

--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -62,12 +62,15 @@ async fn run_ecs_health_check_service(
         }
     };
 
-    let data_plane_status = match &data_plane {
+    let data_plane_log = match &data_plane {
         HealthCheckVersion::V0(log) | HealthCheckVersion::V1(log) => log,
     };
 
-    let status_to_return =
-        std::cmp::max(control_plane.status_code(), data_plane_status.status_code());
+    let status_to_return = [control_plane.status.clone(), data_plane_log.status.clone()]
+        .iter()
+        .max()
+        .unwrap()
+        .clone();
 
     let combined_log = CombinedHealthCheckLog {
         control_plane,

--- a/shared/src/server/health.rs
+++ b/shared/src/server/health.rs
@@ -1,4 +1,11 @@
 use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum HealthCheckVersion {
+    V0(HealthCheckLog),
+    V1(HealthCheckLog),
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HealthCheckLog {
     pub status: HealthCheckStatus,


### PR DESCRIPTION
# Why
Soon we'll introduce diagnostics from the data-plane with a completely different schema to the basic, existing `HealthCheckLog` format. 

We guarantee compatibility between the control-plane and existing (potentially v0) data-plane versions. Because of this, we need to be able to version the responses coming back from the data-plane so we can safely deserialise them.
 
# How
* Wrap the existing logs in `HealthCheckVersion`, V0 is the current behaviour and V1 is what we're going to build.
* This is a no-op for now because they both wrap the existing `HealthCheckLog`, follow up will be to place the new, more detailed diagnostic struct in V1.
* There are some stylistic things that would be nice to tidy up here, but leaving until we actually start implemented V1.
