### PR TITLE
Add ability for data-plane services to surface diagnostics to the control-plane

### DIFF
--- a/data-plane/src/acme/mod.rs
+++ b/data-plane/src/acme/mod.rs
@@ -23,7 +23,7 @@ pub mod mocks;
 
 pub async fn get_trusted_cert() -> Result<(Vec<u8>, CertifiedKey), AcmeError> {
     let config_client = ConfigClient::new();
-    let e3_client = E3Client::new();
+    let e3_client = E3Client::new(None);
     let enclave_context = EnclaveContext::get()?;
 
     let trusted_key_pair: PKey<openssl::pkey::Private> =

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -46,7 +46,7 @@ impl Environment {
     #[cfg(not(feature = "tls_termination"))]
     pub fn new() -> Environment {
         let cert_provisioner_client = CertProvisionerClient::new();
-        let e3_client = E3Client::new();
+        let e3_client = E3Client::new(None);
         let config_client = ConfigClient::new();
         Environment {
             cert_provisioner_client,

--- a/data-plane/src/health/agent.rs
+++ b/data-plane/src/health/agent.rs
@@ -1,14 +1,64 @@
+use futures::lock::MutexGuard;
 use hyper::{client::HttpConnector, header, Body, Client, Method, Request};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use shared::server::health::UserProcessHealth;
 use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, TryLockError};
 use thiserror::Error;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::{
     channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender,
 };
 
 use crate::{ContextError, EnclaveContext};
+
+#[derive(Error, Debug)]
+pub enum RecordError {
+    #[error("sad!")]
+    Mutex(String),
+    #[error("sad!")]
+    Send(#[from] mpsc::error::SendError<Diagnostic>),
+    #[error("sad!")]
+    NoSender,
+}
+
+#[derive(Debug)]
+pub struct Diagnostic {
+    pub label: String,
+}
+
+pub trait Recordable {
+    fn recorder(&self) -> Option<DiagnosticSender>;
+}
+
+#[allow(unused)]
+pub trait Record {
+    fn diagnostic(&self, diagnostic: Diagnostic);
+}
+
+impl<T: Recordable> Record for T {
+    fn diagnostic(&self, diagnostic: Diagnostic) {
+        if let Some(hc_sender) = self.recorder().clone() {
+            let lock = match hc_sender.try_lock() {
+                Ok(lock) => lock,
+                Err(e) => {
+                    log::error!("Couldn't acquire lock for diagnostic sender {e:?}");
+                    return;
+                }
+            };
+
+            match lock.send(diagnostic) {
+                Ok(_) => (),
+                Err(e) => log::error!("Couldn't send diagnostic over channel {e:?}"),
+            };
+        } else {
+            log::warn!("tried to record diagnostic {diagnostic:?} where sender wasn't present");
+        };
+    }
+}
+
+pub type DiagnosticSender = Arc<Mutex<mpsc::UnboundedSender<Diagnostic>>>;
 
 enum HealthcheckAgentState {
     Initializing,

--- a/data-plane/src/health/diagnostic.rs
+++ b/data-plane/src/health/diagnostic.rs
@@ -1,0 +1,30 @@
+use shared::server::diagnostic::{Diagnostic, DiagnosticSender};
+
+pub trait Diagnosable {
+    fn sender(&self) -> Option<DiagnosticSender>;
+    fn label() -> String;
+}
+
+#[allow(unused)]
+pub trait Diagnose {
+    fn diagnostic(&self, diag: serde_json::Value);
+}
+
+impl<T: Diagnosable> Diagnose for T {
+    fn diagnostic(&self, data: serde_json::Value) {
+        if let Some(diag_sender) = self.sender().clone() {
+            match diag_sender.send(Diagnostic {
+                label: Self::label(),
+                data,
+            }) {
+                Ok(_) => (),
+                Err(e) => log::error!("Error sending diagnostic over channel {e:?}"),
+            };
+        } else {
+            log::warn!(
+                "tried to record diagnostic in {} where sender wasn't present",
+                Self::label()
+            );
+        };
+    }
+}

--- a/data-plane/src/health/mod.rs
+++ b/data-plane/src/health/mod.rs
@@ -1,4 +1,4 @@
-mod agent;
+pub mod agent;
 
 use agent::UserProcessHealthcheckSender;
 

--- a/data-plane/src/health/mod.rs
+++ b/data-plane/src/health/mod.rs
@@ -1,21 +1,32 @@
-pub mod agent;
+mod agent;
+pub mod diagnostic;
 
-use agent::UserProcessHealthcheckSender;
+use agent::{DiagnosticReceiver, HealthcheckAgentRequest, HealthcheckAgentSender};
 
 use hyper::header;
 use hyper::{service::service_fn, Body, Response};
 use shared::server::get_vsock_server;
-use shared::server::health::{DataPlaneDiagnostic, DataPlaneState, UserProcessHealth};
+use shared::server::health::{DataPlaneDiagnostic, DataPlaneState};
 use shared::server::CID::Enclave;
 use shared::{server::Listener, ENCLAVE_HEALTH_CHECK_PORT};
+use thiserror::Error;
+use tokio::sync::{mpsc::error::SendError, oneshot::error::RecvError};
 
-use crate::health::agent::HealthcheckStatusRequest;
+#[derive(Error, Debug)]
+pub enum HealthCheckAgentChannelErr {
+    #[error("Failed to send healthcheck to user process on channel {0}")]
+    Send(#[from] SendError<HealthcheckAgentRequest>),
+    #[error("Failed to receive healthcheck from on channel {0}")]
+    Receive(#[from] RecvError),
+}
 
 fn spawn_customer_healthcheck_agent(
     customer_process_port: u16,
     healthcheck: Option<String>,
-) -> UserProcessHealthcheckSender {
-    let (agent, healthcheck_channel) = agent::default_agent(customer_process_port, healthcheck);
+    diag_recv: DiagnosticReceiver,
+) -> HealthcheckAgentSender {
+    let (agent, healthcheck_channel) =
+        agent::default_agent(customer_process_port, healthcheck, diag_recv);
     tokio::spawn(async move {
         log::info!("Spawning healthcheck agent.");
         agent.run().await;
@@ -23,9 +34,13 @@ fn spawn_customer_healthcheck_agent(
     healthcheck_channel
 }
 
-pub async fn start_health_check_server(customer_process_port: u16, healthcheck: Option<String>) {
-    let user_process_healthcheck_channel =
-        spawn_customer_healthcheck_agent(customer_process_port, healthcheck);
+pub async fn start_health_check_server(
+    customer_process_port: u16,
+    healthcheck: Option<String>,
+    diag_recv: DiagnosticReceiver,
+) {
+    let hc_agent_channel =
+        spawn_customer_healthcheck_agent(customer_process_port, healthcheck, diag_recv);
     let mut health_check_server = get_vsock_server(ENCLAVE_HEALTH_CHECK_PORT, Enclave)
         .await
         .unwrap();
@@ -40,15 +55,18 @@ pub async fn start_health_check_server(customer_process_port: u16, healthcheck: 
             }
         };
 
-        let user_process_channel = user_process_healthcheck_channel.clone();
+        let hc_agent_channel = hc_agent_channel.clone();
         let service = service_fn(move |_| {
-            let user_process_channel = user_process_channel.clone();
+            let hc_agent_channel = hc_agent_channel.clone();
             async move {
-                let user_process_health = check_user_process_health(&user_process_channel).await;
+                let dp_diagnostic = recv_diagnostic_from_agent(&hc_agent_channel).await;
 
-                let result = DataPlaneState::Initialized(DataPlaneDiagnostic {
-                    user_process: user_process_health,
-                });
+                let result = match dp_diagnostic {
+                    Ok(diag) => DataPlaneState::Initialized(diag),
+                    Err(e) => {
+                        DataPlaneState::Error(format!("Failed to get diagnostic from agent: {e}"))
+                    }
+                };
 
                 Response::builder()
                     .status(200)
@@ -67,18 +85,11 @@ pub async fn start_health_check_server(customer_process_port: u16, healthcheck: 
     }
 }
 
-async fn check_user_process_health(channel: &UserProcessHealthcheckSender) -> UserProcessHealth {
-    let (request, receiver) = HealthcheckStatusRequest::new();
-    if let Err(e) = channel.send(request) {
-        return UserProcessHealth::Error(format!(
-            "Failed to send healthcheck to user process on channel {e:?}"
-        ));
-    }
+async fn recv_diagnostic_from_agent(
+    channel: &HealthcheckAgentSender,
+) -> Result<DataPlaneDiagnostic, HealthCheckAgentChannelErr> {
+    let (request, receiver) = HealthcheckAgentRequest::new();
+    channel.send(request)?;
 
-    match receiver.await {
-        Ok(health) => health,
-        Err(e) => UserProcessHealth::Error(format!(
-            "Failed to receive healthcheck from on channel {e:?}"
-        )),
-    }
+    Ok(receiver.await?)
 }

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -1,10 +1,9 @@
-use std::sync::{Arc, Mutex};
-
-use data_plane::health::agent::{Diagnostic, DiagnosticSender};
+use shared::server::diagnostic::{Diagnostic, DiagnosticSender};
 #[cfg(not(feature = "tls_termination"))]
 use shared::server::Listener;
 use shared::server::CID::Enclave;
 use shared::{print_version, server::get_vsock_server_with_proxy_protocol};
+use std::sync::Arc;
 
 #[cfg(feature = "network_egress")]
 use data_plane::dns::egressproxy::EgressProxy;
@@ -67,19 +66,19 @@ fn main() {
         }
     };
 
-    let (hc_sender, hc_receiver) = mpsc::unbounded_channel::<Diagnostic>();
-    let hc_sender = Arc::new(Mutex::new(hc_sender));
+    let (diag_sender, diag_recv) = mpsc::unbounded_channel::<Diagnostic>();
+    let diag_sender = Arc::new(diag_sender);
 
     runtime.block_on(async move {
         tokio::join!(
-            start(data_plane_port, hc_sender),
-            start_health_check_server(data_plane_port, ctx.healthcheck)
+            start(data_plane_port, diag_sender),
+            start_health_check_server(data_plane_port, ctx.healthcheck, diag_recv),
         );
     });
 }
 
 #[cfg(not(feature = "network_egress"))]
-async fn start(data_plane_port: u16, hc_sender: DiagnosticSender) {
+async fn start(data_plane_port: u16, diag_sender: DiagnosticSender) {
     use data_plane::{crypto::api::CryptoApi, stats::StatsProxy};
 
     StatsClient::init();
@@ -95,7 +94,7 @@ async fn start(data_plane_port: u16, hc_sender: DiagnosticSender) {
     log::info!("Running data plane with egress disabled");
     let (_, e3_api_result, stats_result, _) = tokio::join!(
         start_data_plane(data_plane_port, context),
-        CryptoApi::listen(hc_sender),
+        CryptoApi::listen(diag_sender),
         StatsProxy::listen(),
         ClockSync::run(ENCLAVE_CLOCK_SYNC_INTERVAL)
     );
@@ -110,7 +109,7 @@ async fn start(data_plane_port: u16, hc_sender: DiagnosticSender) {
 }
 
 #[cfg(feature = "network_egress")]
-async fn start(data_plane_port: u16) {
+async fn start(data_plane_port: u16, diag_sender: DiagnosticSender) {
     use data_plane::{crypto::api::CryptoApi, stats::StatsProxy};
 
     StatsClient::init();
@@ -125,7 +124,7 @@ async fn start(data_plane_port: u16) {
     let (_, dns_result, e3_api_result, egress_result, stats_result, _) = tokio::join!(
         start_data_plane(data_plane_port, context.clone()),
         EnclaveDnsProxy::bind_server(context.egress.allow_list),
-        CryptoApi::listen(),
+        CryptoApi::listen(diag_sender),
         EgressProxy::listen(),
         StatsProxy::listen(),
         ClockSync::run(ENCLAVE_CLOCK_SYNC_INTERVAL)

--- a/data-plane/src/server/server.rs
+++ b/data-plane/src/server/server.rs
@@ -39,7 +39,7 @@ where
         .with_attestable_cert()
         .await
         .expect("Failed to create tls server");
-    let e3_client = Arc::new(E3Client::new());
+    let e3_client = Arc::new(E3Client::new(None));
 
     let (tx, rx): (
         UnboundedSender<LogHandlerMessage>,

--- a/data-plane/src/server/tls/inter_ca_retreiver.rs
+++ b/data-plane/src/server/tls/inter_ca_retreiver.rs
@@ -17,7 +17,7 @@ impl InterCaRetreiver {
     pub fn new() -> Self {
         let cert_provisioner_client = cert_provisioner_client::CertProvisionerClient::new();
         let config_client = config_client::ConfigClient::new();
-        let e3_client = E3Client::new();
+        let e3_client = E3Client::new(None);
         let env = Environment { e3_client };
 
         Self {

--- a/shared/src/server/diagnostic.rs
+++ b/shared/src/server/diagnostic.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+pub type DiagnosticSender = Arc<mpsc::UnboundedSender<Diagnostic>>;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Diagnostic {
+    pub label: String,
+    pub data: serde_json::Value,
+}

--- a/shared/src/server/health.rs
+++ b/shared/src/server/health.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::diagnostic::Diagnostic;
+
 /// This is for representing healthcheck verions across the control-plane <-> data-plane http
 /// boundary. It's not tied to v0/v1 enclaves release. There are many v1 enclaves that will
 /// report v0 healthchecks until they are updated.
@@ -119,6 +121,7 @@ pub enum DataPlaneState {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DataPlaneDiagnostic {
     pub user_process: UserProcessHealth,
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 impl DataPlaneDiagnostic {

--- a/shared/src/server/mod.rs
+++ b/shared/src/server/mod.rs
@@ -7,6 +7,7 @@ pub mod proxy_protocol;
 pub mod sni;
 pub mod tcp;
 pub use tcp::{TcpServer, TcpServerWithProxyProtocol};
+pub mod diagnostic;
 
 #[cfg(feature = "enclave")]
 pub mod vsock;


### PR DESCRIPTION
# Why
This PR defines new traits that enable collection of diagnostics from various services within the data-plane.
By implementing the `Diagnosable` trait, a service can report aribtary JSON diagnostics to the control-plane which are then logged.

These diagnostics are surfaced by the data-plane to the control-plane, when the control-plane requests a healthcheck. Although they are surfaced alongside the healthcheck, they are not considered part of the healthcheck itself.
The `is_healthy` method which is used to describe the health of the enclave to ECS, currently only considers the status of the user process.

In the future more services can surface diagnostics using this implementation, at that point it may be useful to consider certain diagnostics as part of the healthcheck.

# How
Diagnostics will be surface to the control-plane as serialized JSON.


```json
{
  "controlPlane": "Ok",
  "dataPlane": {
    "Initialized": {
      "user_process": {
        "Initialized": {
          "Response": {
            "status_code": 200
            "body": { "status": "happy" }
          }
        }
      },
      "diagnostics": [
        {
            "label": "E3Client",
            "data": {
              ...payloadOfDiagnostic,
              // eg
              "decryption_err": "...."
            }
        }
      ]
    }
  }
}
```
