### PR TITLE
Ignore broken pipe errors

### DIFF
--- a/shared/src/utils.rs
+++ b/shared/src/utils.rs
@@ -1,11 +1,17 @@
+use std::io::ErrorKind;
+
 use tokio::io::{AsyncRead, AsyncWrite};
 
-pub async fn pipe_streams<T1, T2>(mut src: T1, mut dest: T2) -> Result<(u64, u64), tokio::io::Error>
+pub async fn pipe_streams<T1, T2>(mut src: T1, mut dest: T2) -> Result<(), tokio::io::Error>
 where
     T1: AsyncRead + AsyncWrite + Unpin,
     T2: AsyncRead + AsyncWrite + Unpin,
 {
-    tokio::io::copy_bidirectional(&mut src, &mut dest).await
+    match tokio::io::copy_bidirectional(&mut src, &mut dest).await {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 pub struct HexSlice<'a>(&'a [u8]);


### PR DESCRIPTION
# Why
Broken pipe errors are flooding the logs on every successful passthrough because copy_bidirectional does not shut down both directions when an EOF is sent on one https://docs.rs/tokio/latest/tokio/io/fn.copy_bidirectional.html

# How
Ignore broken pipe errors, any other errors will still be surfaced. Other option here is to add our own impl but this will clean up the logs for now
