### PR TITLE
Introduce retries to data plane environment init flow

### DIFF
--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -94,7 +94,7 @@ impl Environment {
                 Ok(response) => return Ok(response),
                 Err(e) if attempts < 3 => {
                     log::error!("Request failed during environment init flow - {e:?}");
-                    tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+                    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                 }
                 Err(e) => return Err(e),
             }

--- a/data-plane/src/env/mod.rs
+++ b/data-plane/src/env/mod.rs
@@ -1,9 +1,3 @@
-use std::{
-    fs::{File, OpenOptions},
-    future::Future,
-    io::Write,
-};
-
 #[cfg(not(feature = "tls_termination"))]
 use crate::cert_provisioner_client::CertProvisionerClient;
 #[cfg(not(feature = "tls_termination"))]
@@ -12,6 +6,12 @@ use crate::{base_tls_client::ClientError, ContextError};
 use hyper::header::InvalidHeaderValue;
 use serde_json::json;
 use shared::server::config_server::requests::Secret;
+#[cfg(not(feature = "tls_termination"))]
+use std::future::Future;
+use std::{
+    fs::{File, OpenOptions},
+    io::Write,
+};
 use thiserror::Error;
 
 use crate::e3client::{CryptoRequest, CryptoResponse, E3Api, E3Client};

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -187,6 +187,8 @@ where
             "An error occurred initializing the enclave environment — {:?}",
             e
         );
+        // If the environment fails to initialize, we should exit.
+        return;
     }
 
     loop {


### PR DESCRIPTION
# Why

The data plane startup flow can run into errors seeding its environment. If these requests fail, the enclave can end up in a bad state and unable to correctly receive traffic.

# How

Update the environment loading calls to retry multiple times before erroring.