### PR TITLE
ETR-2815 cache attestation docs

### DIFF
--- a/data-plane/src/cache.rs
+++ b/data-plane/src/cache.rs
@@ -5,10 +5,18 @@ use tokio::sync::Mutex;
 use crate::crypto::token::AttestationAuth;
 
 const E3_TOKEN_LIFETIME: u64 = 280;
+const ATTESTATION_DOC_LIFETIME: u64 = 300; // 5 minutes
 
 pub static E3_TOKEN: Lazy<Mutex<TimedSizedCache<String, AttestationAuth>>> = Lazy::new(|| {
     Mutex::new(TimedSizedCache::with_size_and_lifespan(
         1,
         E3_TOKEN_LIFETIME,
+    ))
+});
+
+pub static ATTESTATION_DOC: Lazy<Mutex<TimedSizedCache<String, String>>> = Lazy::new(|| {
+    Mutex::new(TimedSizedCache::with_size_and_lifespan(
+        1,
+        ATTESTATION_DOC_LIFETIME,
     ))
 });

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -66,7 +66,7 @@ where
             let base64_doc = match cache.cache_get(&attestation_doc_key) {
                 Some(ad) => ad.clone(),
                 None => {
-                    doc = match attest::get_attestation_doc(None, None) {
+                    let doc = match attest::get_attestation_doc(None, None) {
                         Ok(ad) => ad,
                         Err(e) => return Ok(build_internal_error_response(None)),
                     };

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -1,3 +1,4 @@
+use cached::Cached;
 use hyper::http::{Request, Response};
 use hyper::Body;
 use serde::{Deserialize, Serialize};
@@ -5,6 +6,7 @@ use std::future::Future;
 use std::pin::Pin;
 use tower::{Layer, Service};
 
+use crate::cache::ATTESTATION_DOC;
 use crate::crypto::attest;
 use crate::server::http::build_internal_error_response;
 use crate::server::tls::TRUSTED_PUB_CERT;

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -66,11 +66,11 @@ where
             let base64_doc = match cache.cache_get(&attestation_doc_key) {
                 Some(ad) => ad.clone(),
                 None => {
-                    attestation_doc = match attest::get_attestation_doc(None, None) {
-                        Ok(attestation_doc) => attestation_doc,
+                    doc = match attest::get_attestation_doc(None, None) {
+                        Ok(ad) => ad,
                         Err(e) => return Ok(build_internal_error_response(None)),
                     };
-                    let base64_doc = base64::encode(attestation_doc);
+                    let base64_doc = base64::encode(doc);
                     cache.cache_set(attestation_doc_key, base64_doc.clone());
                     log::info!("Attestation doc generated and cached.");
                     base64_doc

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -71,8 +71,8 @@ where
                         Ok(ad) => ad,
                         Err(e) => {
                             log::error!("Failed to generate attestation doc. Error: {:?}", e);
-                            return Ok(build_internal_error_response(None))
-                        },
+                            return Ok(build_internal_error_response(None));
+                        }
                     };
                     let base64_doc = base64::encode(doc);
                     cache.cache_set(attestation_doc_key, base64_doc.clone());

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -70,6 +70,7 @@ where
                     };
                     let base64_doc = base64::encode(attestation_doc);
                     cache.cache_set(attestation_doc_key, base64_doc.clone());
+                    log::info!("Attestation doc generated and cached.");
                     base64_doc
                 }
             };


### PR DESCRIPTION
# Why
We don't need to generate an AD on every single request. We can cache it and re-use the request.

# How
Use existing cache lib with new cache for attestation doc that is evicted every five minutes.
