### PR TITLE
Publish file descriptor stats to statsd

### DIFF
--- a/data-plane/src/stats_client.rs
+++ b/data-plane/src/stats_client.rs
@@ -1,7 +1,6 @@
 use cadence::StatsdClient;
 use cadence::{BufferedUdpMetricSink, QueuingMetricSink};
 use cadence_macros::{set_global_default, statsd_count, statsd_gauge};
-use log::logger;
 use shared::stats::StatsError;
 use shared::{publish_count, publish_count_dynamic_label, publish_gauge, ENCLAVE_STATSD_PORT};
 use std::fs;

--- a/data-plane/src/stats_client.rs
+++ b/data-plane/src/stats_client.rs
@@ -1,6 +1,7 @@
 use cadence::StatsdClient;
 use cadence::{BufferedUdpMetricSink, QueuingMetricSink};
 use cadence_macros::{set_global_default, statsd_count, statsd_gauge};
+use log::logger;
 use shared::stats::StatsError;
 use shared::{publish_count, publish_count_dynamic_label, publish_gauge, ENCLAVE_STATSD_PORT};
 use std::fs;
@@ -73,28 +74,42 @@ impl StatsClient {
     }
 
     pub fn try_record_system_metrics() -> Result<(), StatsError> {
-        let mem_info = sys_info::mem_info()?;
-        let cpu = sys_info::loadavg()?;
-        let cpu_num = sys_info::cpu_num()?;
-        let (allocated, free, max) = Self::get_file_descriptor_info()?;
+        let mem_info =
+            sys_info::mem_info().map_err(|e| log::error!("Couldn't obtain mem info: {e}"));
+        let cpu = sys_info::loadavg().map_err(|e| log::error!("Couldn't obtain cpu info: {e}"));
+        let cpu_num = sys_info::cpu_num().map_err(|e| log::error!("Couldn't obtain cpu num: {e}"));
+        let fd_info = Self::get_file_descriptor_info()
+            .map_err(|e| log::error!("Couldn't obtain fd info: {e}"));
 
         if let Ok(context) = EnclaveContext::get() {
-            publish_gauge!(
-                "evervault.enclaves.memory.total",
-                mem_info.total as f64,
-                context
-            );
-            publish_gauge!(
-                "evervault.enclaves.memory.avail",
-                mem_info.avail as f64,
-                context
-            );
-            publish_gauge!("evervault.enclaves.cpu.cores", cpu_num as f64, context);
-            publish_gauge!("evervault.enclaves.cpu.one", cpu.one, context);
-            publish_gauge!("evervault.enclaves.fd.allocated", allocated, context);
-            publish_gauge!("evervault.enclaves.fd.free", free, context);
-            publish_gauge!("evervault.enclaves.fd.max", max, context);
-        };
+            if let Ok(mem_info) = mem_info {
+                publish_gauge!(
+                    "evervault.enclaves.memory.total",
+                    mem_info.total as f64,
+                    context
+                );
+                publish_gauge!(
+                    "evervault.enclaves.memory.avail",
+                    mem_info.avail as f64,
+                    context
+                );
+            }
+
+            if let Ok(cpu_num) = cpu_num {
+                publish_gauge!("evervault.enclaves.cpu.cores", cpu_num as f64, context);
+            }
+
+            if let Ok(cpu) = cpu {
+                publish_gauge!("evervault.enclaves.cpu.one", cpu.one, context);
+            }
+
+            if let Ok((allocated, free, max)) = fd_info {
+                publish_gauge!("evervault.enclaves.fd.allocated", allocated, context);
+                publish_gauge!("evervault.enclaves.fd.free", free, context);
+                publish_gauge!("evervault.enclaves.fd.max", max, context);
+            }
+        }
+
         Ok(())
     }
 }

--- a/data-plane/src/stats_client.rs
+++ b/data-plane/src/stats_client.rs
@@ -3,6 +3,7 @@ use cadence::{BufferedUdpMetricSink, QueuingMetricSink};
 use cadence_macros::{set_global_default, statsd_count, statsd_gauge};
 use shared::stats::StatsError;
 use shared::{publish_count, publish_count_dynamic_label, publish_gauge, ENCLAVE_STATSD_PORT};
+use std::fs;
 use std::net::UdpSocket;
 
 use crate::EnclaveContext;
@@ -31,6 +32,26 @@ impl StatsClient {
         }
     }
 
+    fn get_file_descriptor_info() -> Result<(u64, u64, u64), StatsError> {
+        let content = fs::read_to_string("/proc/sys/fs/file-nr")?;
+        let parts: Vec<&str> = content.split_whitespace().collect();
+
+        if parts.len() == 3 {
+            let allocated: u64 = parts[0]
+                .parse()
+                .map_err(|_| StatsError::FDUsageParseError)?;
+            let free: u64 = parts[1]
+                .parse()
+                .map_err(|_| StatsError::FDUsageParseError)?;
+            let max: u64 = parts[2]
+                .parse()
+                .map_err(|_| StatsError::FDUsageParseError)?;
+            Ok((allocated, free, max))
+        } else {
+            Err(StatsError::FDUsageReadError)
+        }
+    }
+
     pub fn record_encrypt() {
         if let Ok(context) = EnclaveContext::get() {
             publish_count!("evervault.enclaves.encrypt.count", 1, context);
@@ -55,6 +76,7 @@ impl StatsClient {
         let mem_info = sys_info::mem_info()?;
         let cpu = sys_info::loadavg()?;
         let cpu_num = sys_info::cpu_num()?;
+        let (allocated, free, max) = Self::get_file_descriptor_info()?;
 
         if let Ok(context) = EnclaveContext::get() {
             publish_gauge!(
@@ -69,6 +91,9 @@ impl StatsClient {
             );
             publish_gauge!("evervault.enclaves.cpu.cores", cpu_num as f64, context);
             publish_gauge!("evervault.enclaves.cpu.one", cpu.one, context);
+            publish_gauge!("evervault.enclaves.fd.allocated", allocated, context);
+            publish_gauge!("evervault.enclaves.fd.free", free, context);
+            publish_gauge!("evervault.enclaves.fd.max", max, context);
         };
         Ok(())
     }

--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -178,6 +178,15 @@ describe("Enclave is runnning", () => {
         expect(keys).to.include(
           "evervault.enclaves.cpu.cores;enclave_uuid=enclave_123;app_uuid=app_12345678"
         );
+        expect(keys).to.include(
+          "evervault.enclaves.fd.allocated;enclave_uuid=enclave_123;app_uuid=app_12345678"
+        );
+        expect(keys).to.include(
+          "evervault.enclaves.fd.max;enclave_uuid=enclave_123;app_uuid=app_12345678"
+        );
+        expect(keys).to.include(
+          "evervault.enclaves.fd.free;enclave_uuid=enclave_123;app_uuid=app_12345678"
+        );
       } finally {
         sysClient.destroy();
         done();

--- a/shared/src/stats.rs
+++ b/shared/src/stats.rs
@@ -11,6 +11,10 @@ pub enum StatsError {
     MetricError(#[from] MetricError),
     #[error("IO error {0}")]
     IOError(#[from] Error),
+    #[error("Couldn't parse file descriptor values info from /proc/sys/fs/file-nr")]
+    FDUsageParseError,
+    #[error("Couldn't read file descriptor info from /proc/sys/fs/file-nr")]
+    FDUsageReadError,
 }
 
 #[macro_export]


### PR DESCRIPTION
# Why
We need to track fds in use stats to monitor the enclave under heavy load

# How
Use `/proc/sys/fs/file-nr` to get max, allocated and free fds
fd in use = allocated - free

[From kernel docs](https://www.kernel.org/doc/Documentation/sysctl/fs.txt):
> file-nr denote the number of allocated file handles, the number
of allocated but unused file handles, and the maximum number of
file handles

[this](https://www.netadmintools.com/how-many-open-files/) is worth a read re file-nr vs `lsof | wc -l`
