### PR TITLE
Add shutdown mechanism for critical in-Enclave services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "pem",
+ "pin-project",
  "rand",
  "regex",
  "rlimit",

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -5,10 +5,24 @@ edition = "2021"
 authors = ["Evervault <engineering@evervault.com>"]
 
 [dependencies]
-hyper = { version = "0.14.4", features = ["server","http1","http2","tcp","stream","client"] }
-tokio = { version = "1.24.2", features = ["net", "macros", "rt", "rt-multi-thread", "io-util", "time"] }
+hyper = { version = "0.14.4", features = [
+  "server",
+  "http1",
+  "http2",
+  "tcp",
+  "stream",
+  "client",
+] }
+tokio = { version = "1.24.2", features = [
+  "net",
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "io-util",
+  "time",
+] }
 openssl = { workspace = true }
-chrono =  { version = "0.4.22", default-features = false, features = ["serde"]}
+chrono = { version = "0.4.22", default-features = false, features = ["serde"] }
 aws-nitro-enclaves-nsm-api = "0.2.1"
 aws-nitro-enclaves-cose = "0.5.0"
 serde_cbor = "0.11"
@@ -41,13 +55,19 @@ mockall = "0.11.4"
 uuid = { version = "1.4.1", features = ["v4"] }
 log = { version = "0.4.19", features = ["max_level_debug"] }
 rlimit = { version = "0.10.1", optional = true }
-hyper-rustls = { version = "0.24.1", default-features = false, features = ["http1","http2","tls12","tokio-runtime"] }
+hyper-rustls = { version = "0.24.1", default-features = false, features = [
+  "http1",
+  "http2",
+  "tls12",
+  "tokio-runtime",
+] }
 chrono-tz = { version = "0.8.3" }
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.5.0", features = ["catch-panic"] }
 libc = "0.2.150"
 serial_test = "3.0.0"
 regex = "1.10.6"
+pin-project = "1"
 
 
 [dev-dependencies]

--- a/data-plane/src/health/agent.rs
+++ b/data-plane/src/health/agent.rs
@@ -624,10 +624,12 @@ mod test {
             "https".into(),
         );
         agent.state = super::HealthcheckAgentState::Ready;
-        shutdown_channel.try_send(crate::health::notify_shutdown::Service::DataPlane).unwrap();
+        shutdown_channel
+            .try_send(crate::health::notify_shutdown::Service::DataPlane)
+            .unwrap();
 
         agent.perform_healthcheck().await;
-        
+
         let healthcheck_result = agent.buffer.iter().max().unwrap();
         assert!(healthcheck_result.is_error());
         // clear agent buffer to remove above error

--- a/data-plane/src/health/mod.rs
+++ b/data-plane/src/health/mod.rs
@@ -1,13 +1,20 @@
 mod agent;
+pub mod notify_shutdown;
 
 use agent::UserProcessHealthcheckSender;
 
 use hyper::header;
 use hyper::{service::service_fn, Body, Response};
-use shared::server::get_vsock_server;
+use notify_shutdown::Service;
 use shared::server::health::{DataPlaneDiagnostic, DataPlaneState, UserProcessHealth};
 use shared::server::CID::Enclave;
+use shared::server::get_vsock_server;
+#[cfg(not(feature = "enclave"))]
+use shared::server::TcpServer;
+#[cfg(feature = "enclave")]
+use shared::server::VsockServer;
 use shared::{server::Listener, ENCLAVE_HEALTH_CHECK_PORT};
+use tokio::sync::mpsc::{Sender, UnboundedSender};
 
 use crate::health::agent::{HealthcheckAgent, HealthcheckStatusRequest};
 
@@ -15,65 +22,87 @@ fn spawn_customer_healthcheck_agent(
     customer_process_port: u16,
     healthcheck: Option<String>,
     use_tls: bool,
-) -> UserProcessHealthcheckSender {
+) -> (UserProcessHealthcheckSender, Sender<Service>) {
     let default_interval = std::time::Duration::from_secs(1);
     if use_tls {
-        let (agent, channel) =
+        let (agent, channel, shutdown_channel) =
             HealthcheckAgent::build_tls_agent(customer_process_port, default_interval, healthcheck);
         tokio::spawn(async move { agent.run().await });
-        channel
+        (channel, shutdown_channel)
     } else {
-        let (agent, channel) =
+        let (agent, channel, shutdown_channel) =
             HealthcheckAgent::build_agent(customer_process_port, default_interval, healthcheck);
         tokio::spawn(async move { agent.run().await });
-        channel
+        (channel, shutdown_channel)
     }
 }
 
-pub async fn start_health_check_server(
+pub async fn build_health_check_server(
     customer_process_port: u16,
     healthcheck: Option<String>,
     use_tls: bool,
-) {
-    let user_process_healthcheck_channel =
+) -> shared::server::error::ServerResult<(HealthcheckServer, Sender<Service>)> {
+    let (user_process_healthcheck_channel, shutdown_notifier) =
         spawn_customer_healthcheck_agent(customer_process_port, healthcheck, use_tls);
-    let mut health_check_server = get_vsock_server(ENCLAVE_HEALTH_CHECK_PORT, Enclave)
-        .await
-        .unwrap();
+    let health_check_server = HealthcheckServer::new(user_process_healthcheck_channel).await?;
+    Ok((health_check_server, shutdown_notifier))
+}
 
-    log::info!("Data plane health check server running on port {ENCLAVE_HEALTH_CHECK_PORT}");
-    loop {
-        let stream = match health_check_server.accept().await {
-            Ok(stream) => stream,
-            Err(e) => {
-                log::error!("Error accepting health check request — {e:?}");
-                continue;
+pub struct HealthcheckServer {
+    user_process_healthcheck_channel: UnboundedSender<HealthcheckStatusRequest>,
+    #[cfg(feature = "enclave")]
+    listener: VsockServer,
+    #[cfg(not(feature = "enclave"))]
+    listener: TcpServer
+}
+
+impl HealthcheckServer {
+    async fn new(
+        user_process_healthcheck_channel: UnboundedSender<HealthcheckStatusRequest>,
+    ) -> shared::server::error::ServerResult<Self> {
+        let listener = get_vsock_server(ENCLAVE_HEALTH_CHECK_PORT, Enclave).await?;
+        Ok(Self {
+            listener,
+            user_process_healthcheck_channel,
+        })
+    }
+
+    pub async fn run(mut self) {
+        log::info!("Data plane health check server running on port {ENCLAVE_HEALTH_CHECK_PORT}");
+        loop {
+            let stream = match self.listener.accept().await {
+                Ok(stream) => stream,
+                Err(e) => {
+                    log::error!("Error accepting health check request — {e:?}");
+                    continue;
+                }
+            };
+
+            let user_process_channel = self.user_process_healthcheck_channel.clone();
+            let service = service_fn(move |_| {
+                let user_process_channel = user_process_channel.clone();
+                async move {
+                    let user_process_health =
+                        check_user_process_health(&user_process_channel).await;
+
+                    let result = DataPlaneState::Initialized(DataPlaneDiagnostic {
+                        user_process: user_process_health,
+                    });
+
+                    Response::builder()
+                        .status(200)
+                        .header(header::CONTENT_TYPE, "application/json;version=1")
+                        .body(Body::from(serde_json::to_string(&result).unwrap()))
+                }
+            });
+
+            if let Err(error) = hyper::server::conn::Http::new()
+                .http1_only(true)
+                .serve_connection(stream, service)
+                .await
+            {
+                log::error!("Data plane health check error: {error}");
             }
-        };
-
-        let user_process_channel = user_process_healthcheck_channel.clone();
-        let service = service_fn(move |_| {
-            let user_process_channel = user_process_channel.clone();
-            async move {
-                let user_process_health = check_user_process_health(&user_process_channel).await;
-
-                let result = DataPlaneState::Initialized(DataPlaneDiagnostic {
-                    user_process: user_process_health,
-                });
-
-                Response::builder()
-                    .status(200)
-                    .header(header::CONTENT_TYPE, "application/json;version=1")
-                    .body(Body::from(serde_json::to_string(&result).unwrap()))
-            }
-        });
-
-        if let Err(error) = hyper::server::conn::Http::new()
-            .http1_only(true)
-            .serve_connection(stream, service)
-            .await
-        {
-            log::error!("Data plane health check error: {error}");
         }
     }
 }

--- a/data-plane/src/health/mod.rs
+++ b/data-plane/src/health/mod.rs
@@ -6,13 +6,13 @@ use agent::UserProcessHealthcheckSender;
 use hyper::header;
 use hyper::{service::service_fn, Body, Response};
 use notify_shutdown::Service;
-use shared::server::health::{DataPlaneDiagnostic, DataPlaneState, UserProcessHealth};
-use shared::server::CID::Enclave;
 use shared::server::get_vsock_server;
+use shared::server::health::{DataPlaneDiagnostic, DataPlaneState, UserProcessHealth};
 #[cfg(not(feature = "enclave"))]
 use shared::server::TcpServer;
 #[cfg(feature = "enclave")]
 use shared::server::VsockServer;
+use shared::server::CID::Enclave;
 use shared::{server::Listener, ENCLAVE_HEALTH_CHECK_PORT};
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 
@@ -53,7 +53,7 @@ pub struct HealthcheckServer {
     #[cfg(feature = "enclave")]
     listener: VsockServer,
     #[cfg(not(feature = "enclave"))]
-    listener: TcpServer
+    listener: TcpServer,
 }
 
 impl HealthcheckServer {

--- a/data-plane/src/health/notify_shutdown.rs
+++ b/data-plane/src/health/notify_shutdown.rs
@@ -26,7 +26,7 @@ impl std::fmt::Display for Service {
 }
 
 /// The notify shutdown service trait is used to support shutdown notifications of any critical service running within the Enclave.
-/// Any future that is converted into a `NotifyShutdownFuture` will send a message containing the service label to the shutdown channel, 
+/// Any future that is converted into a `NotifyShutdownFuture` will send a message containing the service label to the shutdown channel,
 /// allowing the healthcheck agent to move the Enclave into a draining state.
 ///
 /// Note: all critical services are assumed to run indefinitely. If one exits, it's assumed that the Enclave is entering an unhealthy state.

--- a/data-plane/src/health/notify_shutdown.rs
+++ b/data-plane/src/health/notify_shutdown.rs
@@ -1,0 +1,94 @@
+use std::future::Future;
+use std::task::ready;
+use tokio::sync::mpsc::Sender;
+
+/// Enum covering all critical internal services within the Enclave. This is used to reportunexpected shutdowns of services in the Enclave.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Service {
+    DataPlane,
+    CryptoApi,
+    ClockSync,
+    DnsProxy,
+    EgressProxy,
+}
+
+impl std::fmt::Display for Service {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let service_label = match self {
+            Self::DataPlane => "data-plane",
+            Self::CryptoApi => "crypto-api",
+            Self::ClockSync => "clock-sync",
+            Self::DnsProxy => "dns-proxy",
+            Self::EgressProxy => "egress-proxy",
+        };
+        f.write_str(&service_label)
+    }
+}
+
+/// The notify shutdown service trait is used to support shutdown notifications of any critical service running within the Enclave.
+/// Any future that is converted into a `NotifyShutdownFuture` will send a message containing the service label to the shutdown channel, 
+/// allowing the healthcheck agent to move the Enclave into a draining state.
+///
+/// Note: all critical services are assumed to run indefinitely. If one exits, it's assumed that the Enclave is entering an unhealthy state.
+pub trait NotifyShutdown: Future {
+    fn notify_shutdown(
+        self,
+        service: Service,
+        shutdown_channel: Sender<Service>,
+    ) -> NotifyShutdownFuture<Self>
+    where
+        Self: Sized,
+    {
+        NotifyShutdownFuture {
+            inner: self,
+            service,
+            shutdown_channel,
+        }
+    }
+}
+
+impl<F: ?Sized> NotifyShutdown for F where F: Future {}
+
+#[pin_project::pin_project]
+pub struct NotifyShutdownFuture<F: Future> {
+    #[pin]
+    inner: F,
+    service: Service,
+    shutdown_channel: Sender<Service>,
+}
+
+impl<F: Future> Future for NotifyShutdownFuture<F> {
+    type Output = F::Output;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        let result = ready!(this.inner.poll(cx));
+        // We can ignore the error path here as the consumer is held for the lifetime of the healthcheck agent,
+        // and a send error should signify that the Enclave is already unhealthy.
+        log::warn!("{} exiting...", this.service);
+        let _ = this.shutdown_channel.try_send(this.service.clone());
+        std::task::Poll::Ready(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{NotifyShutdown, Service};
+    use tokio::sync::mpsc::channel;
+
+    #[tokio::test]
+    async fn test_notify_shutdown_service_exits_tasks_as_expected() {
+        let (shutdown_channel, mut recv) = channel(1);
+        let fut1 = async move { 1 }.notify_shutdown(Service::DataPlane, shutdown_channel);
+
+        let result = fut1.await;
+        assert_eq!(result, 1);
+        // Assert that the task notified the shutdown channel on exit
+        let msg = recv.try_recv();
+        assert!(msg.is_ok());
+        assert_eq!(msg.unwrap(), Service::DataPlane);
+    }
+}

--- a/data-plane/src/health/notify_shutdown.rs
+++ b/data-plane/src/health/notify_shutdown.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for Service {
             Self::DnsProxy => "dns-proxy",
             Self::EgressProxy => "egress-proxy",
         };
-        f.write_str(&service_label)
+        f.write_str(service_label)
     }
 }
 

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -1,7 +1,6 @@
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::{fs, future::Future, task::ready};
-use tokio_util::sync::CancellationToken;
+use std::fs;
 
 #[cfg(test)]
 pub mod mocks;
@@ -190,71 +189,10 @@ impl FeatureContext {
     }
 }
 
-pub enum CancellableResult<T> {
-    Cancelled,
-    Complete(T),
-}
-
-impl<T> CancellableResult<T> {
-    pub fn is_cancelled(&self) -> bool {
-        matches!(self, Self::Cancelled)
-    }
-
-    pub fn unwrap(self) -> T {
-        match self {
-            Self::Cancelled => panic!("unwrap called on cancelled result"),
-            Self::Complete(result) => result,
-        }
-    }
-}
-
-/// The critical service trait is used to represent the interdepence of the critical in-Enclave services. If any critical service fails,
-/// all other critical services should be cancelled to force the Enclave to be restarted. This process is managed using a cancellation token.
-pub trait Critical: Future {
-    fn critical(self, cancellation_token: CancellationToken) -> CriticalService<Self>
-    where
-        Self: Sized,
-    {
-        CriticalService {
-            inner: self,
-            cancellation_token,
-        }
-    }
-}
-
-impl<F: ?Sized> Critical for F where F: Future {}
-
-#[pin_project::pin_project]
-pub struct CriticalService<F: Future> {
-    #[pin]
-    inner: F,
-    #[pin]
-    cancellation_token: CancellationToken,
-}
-
-impl<F: Future> Future for CriticalService<F> {
-    type Output = CancellableResult<F::Output>;
-
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        let this = self.project();
-        let is_cancelled = this.cancellation_token.is_cancelled();
-        if is_cancelled {
-            return std::task::Poll::Ready(CancellableResult::Cancelled);
-        }
-
-        let result = ready!(this.inner.poll(cx));
-        this.cancellation_token.cancel();
-        std::task::Poll::Ready(CancellableResult::Complete(result))
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use super::{Critical, FeatureContext};
-    use tokio_util::sync::CancellationToken;
+    use super::FeatureContext;
+
     #[cfg(not(feature = "network_egress"))]
     #[test]
     fn test_config_deserialization_without_proxy_protocol() {
@@ -319,58 +257,5 @@ mod test {
             vec![".stripe.com".to_string()]
         );
         assert_eq!(feature_context.healthcheck, Some("/health".into()));
-    }
-
-    #[tokio::test]
-    async fn test_critical_service_exits_tasks_as_expected() {
-        let cancellation_token = CancellationToken::new();
-        let (sender, mut receiver) = tokio::sync::oneshot::channel();
-        let fut1 = async move {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            sender.send(1).unwrap();
-        }
-        .critical(cancellation_token.child_token());
-
-        let fut2 = async move {
-            cancellation_token.cancel();
-            2
-        };
-
-        let (res1, res2) = tokio::join!(fut1, fut2);
-        assert!(res1.is_cancelled());
-        assert_eq!(res2, 2);
-        // Assert that we forced the exit of the async task without it sending a message
-        let msg = receiver.try_recv();
-        assert!(msg.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_critical_services_are_made_interdependent_on_each_other() {
-        let cancellation_token = CancellationToken::new();
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
-        let sender1 = sender.clone();
-
-        let fut1 = async move {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            sender1.send(1).await.unwrap();
-        }
-        .critical(cancellation_token.clone());
-
-        let fut2 = async move {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            sender.send(2).await.unwrap();
-        }
-        .critical(cancellation_token.clone());
-
-        let fut3 = async move { Ok(()) as Result<(), ()> }.critical(cancellation_token.clone());
-
-        let (res1, res2, res3) = tokio::join!(fut1, fut2, fut3);
-        assert!(cancellation_token.is_cancelled());
-        assert_eq!(res3.unwrap(), Ok(()));
-        assert!(res1.is_cancelled());
-        assert!(res2.is_cancelled());
-        // Assert that we forced the exit of the async task without it sending a message
-        let msg = receiver.try_recv();
-        assert!(msg.is_err());
     }
 }

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::{fs, future::Future, task::ready};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(test)]
 pub mod mocks;
@@ -189,9 +190,71 @@ impl FeatureContext {
     }
 }
 
+pub enum CancellableResult<T> {
+    Cancelled,
+    Complete(T),
+}
+
+impl<T> CancellableResult<T> {
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled)
+    }
+
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Cancelled => panic!("unwrap called on cancelled result"),
+            Self::Complete(result) => result,
+        }
+    }
+}
+
+/// The critical service trait is used to represent the interdepence of the critical in-Enclave services. If any critical service fails,
+/// all other critical services should be cancelled to force the Enclave to be restarted. This process is managed using a cancellation token.
+pub trait Critical: Future {
+    fn critical(self, cancellation_token: CancellationToken) -> CriticalService<Self>
+    where
+        Self: Sized,
+    {
+        CriticalService {
+            inner: self,
+            cancellation_token,
+        }
+    }
+}
+
+impl<F: ?Sized> Critical for F where F: Future {}
+
+#[pin_project::pin_project]
+pub struct CriticalService<F: Future> {
+    #[pin]
+    inner: F,
+    #[pin]
+    cancellation_token: CancellationToken,
+}
+
+impl<F: Future> Future for CriticalService<F> {
+    type Output = CancellableResult<F::Output>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        let is_cancelled = this.cancellation_token.is_cancelled();
+        if is_cancelled {
+            return std::task::Poll::Ready(CancellableResult::Cancelled);
+        }
+
+        let result = ready!(this.inner.poll(cx));
+        this.cancellation_token.cancel();
+        std::task::Poll::Ready(CancellableResult::Complete(result))
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::FeatureContext;
+    use super::{Critical, FeatureContext};
+    use tokio_util::sync::CancellationToken;
     #[cfg(not(feature = "network_egress"))]
     #[test]
     fn test_config_deserialization_without_proxy_protocol() {
@@ -256,5 +319,58 @@ mod test {
             vec![".stripe.com".to_string()]
         );
         assert_eq!(feature_context.healthcheck, Some("/health".into()));
+    }
+
+    #[tokio::test]
+    async fn test_critical_service_exits_tasks_as_expected() {
+        let cancellation_token = CancellationToken::new();
+        let (sender, mut receiver) = tokio::sync::oneshot::channel();
+        let fut1 = async move {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            sender.send(1).unwrap();
+        }
+        .critical(cancellation_token.child_token());
+
+        let fut2 = async move {
+            cancellation_token.cancel();
+            2
+        };
+
+        let (res1, res2) = tokio::join!(fut1, fut2);
+        assert!(res1.is_cancelled());
+        assert_eq!(res2, 2);
+        // Assert that we forced the exit of the async task without it sending a message
+        let msg = receiver.try_recv();
+        assert!(msg.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_critical_services_are_made_interdependent_on_each_other() {
+        let cancellation_token = CancellationToken::new();
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
+        let sender1 = sender.clone();
+
+        let fut1 = async move {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            sender1.send(1).await.unwrap();
+        }
+        .critical(cancellation_token.clone());
+
+        let fut2 = async move {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            sender.send(2).await.unwrap();
+        }
+        .critical(cancellation_token.clone());
+
+        let fut3 = async move { Ok(()) as Result<(), ()> }.critical(cancellation_token.clone());
+
+        let (res1, res2, res3) = tokio::join!(fut1, fut2, fut3);
+        assert!(cancellation_token.is_cancelled());
+        assert_eq!(res3.unwrap(), Ok(()));
+        assert!(res1.is_cancelled());
+        assert!(res2.is_cancelled());
+        // Assert that we forced the exit of the async task without it sending a message
+        let msg = receiver.try_recv();
+        assert!(msg.is_err());
     }
 }

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -95,39 +95,39 @@ async fn start(data_plane_port: u16) {
         log::info!("Running data plane with egress enabled");
     }
 
-    let service_results = tokio::join!(
-        start_data_plane(data_plane_port, context.clone()),
-        CryptoApi::listen(),
-        StatsProxy::listen(),
-        ClockSync::run(ENCLAVE_CLOCK_SYNC_INTERVAL),
-        #[cfg(feature = "network_egress")]
-        EnclaveDnsProxy::bind_server(context.egress.allow_list),
-        #[cfg(feature = "network_egress")]
-        EgressProxy::listen(),
-    );
+    // let service_results = tokio::join!(
+    //     start_data_plane(data_plane_port, context.clone()),
+    //     CryptoApi::listen(),
+    //     StatsProxy::listen(),
+    //     ClockSync::run(ENCLAVE_CLOCK_SYNC_INTERVAL),
+    //     #[cfg(feature = "network_egress")]
+    //     EnclaveDnsProxy::bind_server(context.egress.allow_list),
+    //     #[cfg(feature = "network_egress")]
+    //     EgressProxy::listen(),
+    // );
 
-    #[cfg(feature = "network_egress")]
-    let (_, e3_api_result, stats_result, _, dns_result, egress_result) = service_results;
-    #[cfg(not(feature = "network_egress"))]
-    let (_, e3_api_result, stats_result, _) = service_results;
+    // #[cfg(feature = "network_egress")]
+    // let (_, e3_api_result, stats_result, _, dns_result, egress_result) = service_results;
+    // #[cfg(not(feature = "network_egress"))]
+    // let (_, e3_api_result, stats_result, _) = service_results;
 
-    if let Err(e) = e3_api_result {
-        log::error!("An error occurred within the E3 API server — {e:?}");
-    }
+    // if let Err(e) = e3_api_result {
+    //     log::error!("An error occurred within the E3 API server — {e:?}");
+    // }
 
-    if let Err(e) = stats_result {
-        log::error!("An error occurred within the Stats proxy — {e:?}");
-    }
+    // if let Err(e) = stats_result {
+    //     log::error!("An error occurred within the Stats proxy — {e:?}");
+    // }
 
-    #[cfg(feature = "network_egress")]
-    if let Err(e) = dns_result {
-        log::error!("An error occurred within the dns server — {e:?}");
-    }
+    // #[cfg(feature = "network_egress")]
+    // if let Err(e) = dns_result {
+    //     log::error!("An error occurred within the dns server — {e:?}");
+    // }
 
-    #[cfg(feature = "network_egress")]
-    if let Err(e) = egress_result {
-        log::error!("An error occurred within the egress server — {e:?}");
-    }
+    // #[cfg(feature = "network_egress")]
+    // if let Err(e) = egress_result {
+    //     log::error!("An error occurred within the egress server — {e:?}");
+    // }
 }
 
 #[allow(unused_variables)]

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -108,7 +108,6 @@ async fn start(data_plane_port: u16, shutdown_notifier: Sender<Service>) {
     tokio::spawn(async move {
         if let Err(e) = StatsProxy::listen().await {
             log::error!("In-Enclave Stats proxy exited with an error - {e}");
-            return;
         }
     });
 

--- a/data-plane/src/main.rs
+++ b/data-plane/src/main.rs
@@ -105,7 +105,12 @@ async fn start(data_plane_port: u16, shutdown_notifier: Sender<Service>) {
     }
 
     // Schedule non-critical stats proxy
-    tokio::spawn(StatsProxy::listen());
+    tokio::spawn(async move {
+        if let Err(e) = StatsProxy::listen().await {
+            log::error!("In-Enclave Stats proxy exited with an error - {e}");
+            return;
+        }
+    });
 
     // Schedule critical services with notify shutdown futures to ensure healthchecks detect any single critical failure.
     tokio::spawn(

--- a/shared/src/server/health.rs
+++ b/shared/src/server/health.rs
@@ -155,6 +155,10 @@ impl UserProcessHealth {
             }
         }
     }
+
+    pub fn is_error(&self) -> bool {
+      matches!(self, Self::Error(_))
+    }
 }
 
 impl Ord for UserProcessHealth {

--- a/shared/src/server/health.rs
+++ b/shared/src/server/health.rs
@@ -157,7 +157,7 @@ impl UserProcessHealth {
     }
 
     pub fn is_error(&self) -> bool {
-      matches!(self, Self::Error(_))
+        matches!(self, Self::Error(_))
     }
 }
 


### PR DESCRIPTION
# Why

The Enclave runs several services which are critical, but the health of these services is currently decoupled from the healthcheck system. To avoid issues when these services are unhealthy, we want to have a mechanism for these services to be able to notify the healthcheck agent so it can reflect the internal status.

# How

- Implement future extension for `notify_shutdown` which uses a label and a channel to report the shutdown of a service which is expected to be running for the lifetime of the process
  - If one of these futures completes, it will send its service label to the provided channel
- Update the healthcheck agent to expose a channel for sending shutdown notifications
- Update the healthcheck agent's healthcheck logic to check if any critical services have exited before attempting a healthcheck