### PR TITLE
Add notify shutdown to control plane services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ dependencies = [
  "openssl",
  "ppp",
  "rand",
+ "rand_chacha",
  "rustls-pemfile",
  "semver",
  "serde",

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -34,6 +34,7 @@ openssl = { version = "0.10.48", features = ["vendored"] }
 base64 = "0.13.0"
 storage-client-interface = "0.3.0"
 log = { version = "0.4.19", features = ["max_level_debug"] }
+rand_chacha = "0.3.1"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/control-plane/src/dnsproxy.rs
+++ b/control-plane/src/dnsproxy.rs
@@ -1,6 +1,7 @@
 use crate::error::{Result, ServerError};
 use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha12Rng;
 use shared::server::egress::check_dns_allowed_for_domain;
 use shared::server::egress::{cache_ip_for_allowlist, EgressDestinations};
 use shared::server::CID::Parent;
@@ -55,7 +56,7 @@ impl DnsProxy {
         let mut server = get_vsock_server(DNS_PROXY_VSOCK_PORT, Parent).await?;
 
         let allowed_domains = shared::server::egress::get_egress_allow_list_from_env();
-        let mut rng = thread_rng();
+        let mut rng = ChaCha12Rng::from_entropy();
         loop {
             let domains = allowed_domains.clone();
             match server.accept().await {

--- a/control-plane/src/health.rs
+++ b/control-plane/src/health.rs
@@ -3,6 +3,7 @@ use crate::error::ServerError;
 use axum::http::HeaderValue;
 use hyper::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
+use shared::notify_shutdown::Service;
 use shared::server::{
     error::ServerResult,
     health::{ControlPlaneState, DataPlaneState, HealthCheck, HealthCheckLog, HealthCheckVersion},
@@ -12,14 +13,11 @@ use shared::server::{
 use shared::ENCLAVE_HEALTH_CHECK_PORT;
 use std::net::SocketAddr;
 use std::sync::OnceLock;
+use tokio::sync::mpsc::Receiver;
 
 pub static IS_DRAINING: OnceLock<bool> = OnceLock::new();
 
 pub const CONTROL_PLANE_HEALTH_CHECK_PORT: u16 = 3032;
-
-pub struct HealthCheckServer {
-    tcp_server: TcpServer,
-}
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -30,6 +28,7 @@ struct CombinedHealthCheckLog {
 
 pub async fn run_ecs_health_check_service(
     is_draining: bool,
+    control_plane_state: ControlPlaneState,
 ) -> std::result::Result<Response<Body>, ServerError> {
     if is_draining {
         let combined_log = CombinedHealthCheckLog {
@@ -48,15 +47,15 @@ pub async fn run_ecs_health_check_service(
             .body(Body::from(combined_log_json))?);
     };
 
-    let control_plane = ControlPlaneState::Ok;
     let data_plane = health_check_data_plane().await.unwrap_or_else(|e| {
         DataPlaneState::Error(format!("Failed to contact data-plane for healthcheck: {e}")).into()
     });
 
-    let status_to_return = std::cmp::max(control_plane.status_code(), data_plane.status_code());
+    let status_to_return =
+        std::cmp::max(control_plane_state.status_code(), data_plane.status_code());
 
     let combined_log = CombinedHealthCheckLog {
-        control_plane,
+        control_plane: control_plane_state,
         data_plane,
     };
     let combined_log_json = serde_json::to_string(&combined_log).unwrap();
@@ -101,14 +100,17 @@ async fn health_check_data_plane() -> Result<HealthCheckVersion, ServerError> {
     Ok(hc)
 }
 
+pub struct HealthCheckServer {
+    shutdown_receiver: Receiver<Service>,
+    exited_services: Vec<Service>,
+}
+
 impl HealthCheckServer {
-    pub async fn new() -> ServerResult<Self> {
-        let tcp_server = TcpServer::bind(SocketAddr::from((
-            [0, 0, 0, 0],
-            CONTROL_PLANE_HEALTH_CHECK_PORT,
-        )))
-        .await?;
-        Ok(HealthCheckServer { tcp_server })
+    pub fn new(shutdown_receiver: Receiver<Service>) -> Self {
+        Self {
+            shutdown_receiver,
+            exited_services: Vec::new(),
+        }
     }
 
     pub async fn start(&mut self) -> ServerResult<()> {
@@ -116,22 +118,51 @@ impl HealthCheckServer {
             "Control plane health-check server running on port {CONTROL_PLANE_HEALTH_CHECK_PORT}"
         );
 
+        let mut tcp_server = TcpServer::bind(SocketAddr::from((
+            [0, 0, 0, 0],
+            CONTROL_PLANE_HEALTH_CHECK_PORT,
+        )))
+        .await?;
+
         loop {
-            let stream = self.tcp_server.accept().await?;
-            let service = hyper::service::service_fn(move |request: Request<Body>| async move {
-                match request
-                    .headers()
-                    .get("User-Agent")
-                    .map(|value| value.as_bytes())
-                {
-                    Some(b"ECS-HealthCheck") => {
-                        let is_draining = IS_DRAINING.get().is_some();
-                        run_ecs_health_check_service(is_draining).await
+            let stream = tcp_server.accept().await?;
+
+            let cp_state = if let Ok(exited_service) = self.shutdown_receiver.try_recv() {
+                self.exited_services.push(exited_service);
+                ControlPlaneState::Error(format!(
+                    "Critical Control Plane services have exited: {}",
+                    self.serialize_exited_services()
+                ))
+            } else if !self.exited_services.is_empty() {
+                ControlPlaneState::Error(format!(
+                    "Critical Control Plane services have exited: {}",
+                    self.serialize_exited_services()
+                ))
+            } else {
+                ControlPlaneState::Ok
+            };
+
+            let service = hyper::service::service_fn({
+                let cp_state = cp_state.clone();
+                move |request: Request<Body>| {
+                    let cp_state = cp_state.clone();
+                    async move {
+                        match request
+                            .headers()
+                            .get("User-Agent")
+                            .map(|value| value.as_bytes())
+                        {
+                            Some(b"ECS-HealthCheck") => {
+                                let cp_state = cp_state.clone();
+                                let is_draining = IS_DRAINING.get().is_some();
+                                run_ecs_health_check_service(is_draining, cp_state).await
+                            }
+                            _ => Response::builder()
+                                .status(400)
+                                .body(Body::from("Unsupported health check type!"))
+                                .map_err(ServerError::from),
+                        }
                     }
-                    _ => Response::builder()
-                        .status(400)
-                        .body(Body::from("Unsupported health check type!"))
-                        .map_err(ServerError::from),
                 }
             });
             if let Err(error) = hyper::server::conn::Http::new()
@@ -142,6 +173,14 @@ impl HealthCheckServer {
                 log::error!("Health check error: {error}");
             }
         }
+    }
+
+    fn serialize_exited_services(&self) -> String {
+        self.exited_services
+            .iter()
+            .map(|service| service.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 
@@ -158,7 +197,9 @@ mod health_check_tests {
     #[tokio::test]
     async fn test_enclave_health_check_service() {
         // the data-plane status should error, as its not running
-        let response = run_ecs_health_check_service(false).await.unwrap();
+        let response = run_ecs_health_check_service(false, ControlPlaneState::Ok)
+            .await
+            .unwrap();
         assert_eq!(response.status(), 500);
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
@@ -175,7 +216,9 @@ mod health_check_tests {
     async fn test_enclave_health_check_service_with_draining_set_to_true() {
         // the data-plane status should error, as its not running
         IS_DRAINING.set(true).unwrap();
-        let response = run_ecs_health_check_service(true).await.unwrap();
+        let response = run_ecs_health_check_service(true, ControlPlaneState::Ok)
+            .await
+            .unwrap();
         assert_eq!(response.status(), 500);
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;

--- a/control-plane/src/main.rs
+++ b/control-plane/src/main.rs
@@ -97,13 +97,16 @@ async fn main() -> Result<()> {
             .notify_shutdown(Service::AcmeProxy, shutdown_sender.clone()),
     );
 
-    tokio::spawn(async move {
-        if let Err(e) = config_server
-            .listen()
-            .notify_shutdown(Service::ConfigServer, shutdown_sender.clone())
-            .await
-        {
-            log::error!("Error starting config server - {e:?}");
+    tokio::spawn({
+        let shutdown_sender = shutdown_sender.clone();
+        async move {
+            if let Err(e) = config_server
+                .listen()
+                .notify_shutdown(Service::ConfigServer, shutdown_sender)
+                .await
+            {
+                log::error!("Error starting config server - {e:?}");
+            }
         }
     });
 

--- a/shared/src/notify_shutdown.rs
+++ b/shared/src/notify_shutdown.rs
@@ -10,6 +10,10 @@ pub enum Service {
     ClockSync,
     DnsProxy,
     EgressProxy,
+    E3Proxy,
+    ProvisionerProxy,
+    AcmeProxy,
+    ConfigServer,
 }
 
 impl std::fmt::Display for Service {
@@ -20,6 +24,10 @@ impl std::fmt::Display for Service {
             Self::ClockSync => "clock-sync",
             Self::DnsProxy => "dns-proxy",
             Self::EgressProxy => "egress-proxy",
+            Self::E3Proxy => "e3-proxy",
+            Self::ProvisionerProxy => "provisioner-proxy",
+            Self::AcmeProxy => "acme-proxy",
+            Self::ConfigServer => "config-server",
         };
         f.write_str(service_label)
     }

--- a/shared/src/server/health.rs
+++ b/shared/src/server/health.rs
@@ -76,10 +76,11 @@ pub trait HealthCheck {
     fn status_code(&self) -> u16;
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ControlPlaneState {
     Draining,
     Ok,
+    Error(String),
 }
 
 impl HealthCheck for ControlPlaneState {
@@ -87,6 +88,7 @@ impl HealthCheck for ControlPlaneState {
         match self {
             ControlPlaneState::Ok => 200,
             ControlPlaneState::Draining => 500,
+            ControlPlaneState::Error(_) => 500,
         }
     }
 }


### PR DESCRIPTION
# Why
Follow on from https://github.com/evervault/enclaves/pull/256 which added more granular health checks to the data plane. This PR adds the same logic to critical control plane services

# How
- Move the starting of services out of tokio::join and use tokio::spawn instead
- Add notify shutdown channel to update health check if a future completes
- Return 500 in healthcheck if any of the essential tasks have exited
