### PR TITLE
Add configurable cors origin header to attestation endpoint

### DIFF
--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -202,7 +202,7 @@ mod test {
     #[cfg(not(feature = "network_egress"))]
     #[test]
     fn test_config_deserialization_without_proxy_protocol() {
-        let raw_feature_context = r#"{ "api_key_auth": true, "attestation_cors": { "origin, "test.com" }, "trx_logging_enabled": false, "forward_proxy_protocol": false, "trusted_headers": [] }"#;
+        let raw_feature_context = r#"{ "api_key_auth": true, "attestation_cors": { "origin", "test.com" }, "trx_logging_enabled": false, "forward_proxy_protocol": false, "trusted_headers": [] }"#;
         let parsed = serde_json::from_str(raw_feature_context);
         assert!(parsed.is_ok());
         let feature_context: FeatureContext = parsed.unwrap();

--- a/data-plane/src/lib.rs
+++ b/data-plane/src/lib.rs
@@ -202,7 +202,7 @@ mod test {
     #[cfg(not(feature = "network_egress"))]
     #[test]
     fn test_config_deserialization_without_proxy_protocol() {
-        let raw_feature_context = r#"{ "api_key_auth": true, "attestation_cors": { "origin", "test.com" }, "trx_logging_enabled": false, "forward_proxy_protocol": false, "trusted_headers": [] }"#;
+        let raw_feature_context = r#"{ "api_key_auth": true, "attestation_cors": { "origin": "test.com" }, "trx_logging_enabled": false, "forward_proxy_protocol": false, "trusted_headers": [] }"#;
         let parsed = serde_json::from_str(raw_feature_context);
         assert!(parsed.is_ok());
         let feature_context: FeatureContext = parsed.unwrap();

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -73,6 +73,8 @@ where
             return Box::pin(inner.call(req));
         }
 
+        let feature_context = self.feature_context.clone();
+
         Box::pin(async move {
             let attestation_doc_key: String = "attestation_doc".to_string();
             let mut cache = ATTESTATION_DOC.lock().await;
@@ -100,8 +102,7 @@ where
             };
 
             let response_payload = serde_json::to_string(&response).expect("Infallible");
-            let cors_origin = self
-                .feature_context
+            let cors_origin = feature_context
                 .attestation_cors
                 .as_ref()
                 .map_or("*", |cors| cors.origin.as_str());

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -18,6 +18,12 @@ pub struct AttestLayer {
     feature_context: Arc<FeatureContext>,
 }
 
+impl AttestLayer {
+    pub fn new(feature_context: Arc<FeatureContext>) -> Self {
+        Self { feature_context }
+    }
+}
+
 impl<S> Layer<S> for AttestLayer {
     type Service = AttestService<S>;
 

--- a/data-plane/src/server/server.rs
+++ b/data-plane/src/server/server.rs
@@ -71,7 +71,7 @@ where
 
     // Only apply attestation layer in enclave mode
     #[cfg(feature = "enclave")]
-    let service_builder = service_builder.layer(AttestLayer);
+    let service_builder = service_builder.layer(AttestLayer::new(feature_context.clone()));
 
     // layers are invoked in the order that they're registered to the service
     let service = service_builder


### PR DESCRIPTION
# Why
Users need to be able to set cors on the .well-known/attestation endpoint if they are hitting it from the browser.

# How
Pull it from the feature context passed through the docker file.

Start consuming cors context if passed from toml config: https://github.com/evervault/evervault-cli/pull/168
