### PR TITLE
chore: cycle CI secret references

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Configure Production AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -102,8 +102,8 @@ jobs:
       - name: Configure Production AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -140,8 +140,8 @@ jobs:
       - name: Configure Production AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -30,7 +30,7 @@ jobs:
           shared-key: "standard-cache"
       - name: Test control plane
         run: cargo test -p control-plane
-  
+
   get-release-semver:
     needs: [last_test]
     runs-on: ubuntu-latest
@@ -78,8 +78,8 @@ jobs:
       - name: Configure Staging AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -126,8 +126,8 @@ jobs:
       - name: Configure Staging AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy-data-plane-binary-production.yml
+++ b/.github/workflows/deploy-data-plane-binary-production.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Configure Production AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
           aws-region: us-east-1
 
       - uses: Swatinem/rust-cache@v2
@@ -105,8 +105,8 @@ jobs:
       - name: Configure Production AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
           aws-region: us-east-1
 
       - name: Upload data-plane to S3 (${{ matrix.feature }})
@@ -130,8 +130,8 @@ jobs:
       - name: Configure Production AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
           aws-region: us-east-1
 
       - name: Upload version tag to latest
@@ -145,4 +145,4 @@ jobs:
 
       - name: Cloudfront Cache Invalidation
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }} --paths "/runtime/latest/data-plane/*" "/runtime/latest" "/runtime/versions"        
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }} --paths "/runtime/latest/data-plane/*" "/runtime/latest" "/runtime/versions"

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Configure Staging AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
+          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
           aws-region: us-east-1
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy-runtime-installer-production.yml
+++ b/.github/workflows/deploy-runtime-installer-production.yml
@@ -3,8 +3,8 @@ name: Deploy installer to production
 on:
   push:
     tags:
-      - "installer/v*.*.*"      
-    
+      - "installer/v*.*.*"
+
 jobs:
   get-version:
     runs-on: ubuntu-latest
@@ -20,9 +20,9 @@ jobs:
     needs: [get-version]
     uses: ./.github/workflows/deploy-runtime-installer.yml
     with:
-        stage: 'production'
-        version: ${{ needs.get-version.outputs.version }}
+      stage: "production"
+      version: ${{ needs.get-version.outputs.version }}
     secrets:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }} 
+      aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+      aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }}

--- a/.github/workflows/deploy-runtime-installer-staging.yml
+++ b/.github/workflows/deploy-runtime-installer-staging.yml
@@ -11,9 +11,9 @@ jobs:
   build-and-deploy:
     uses: ./.github/workflows/deploy-runtime-installer.yml
     with:
-        stage: 'staging'
-        version: 1
+      stage: "staging"
+      version: 1
     secrets:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
-        aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_STAGING }}           
+      aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
+      aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
+      aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_STAGING }}


### PR DESCRIPTION
# Why
We are using repo based secrets, we should be using those defined at an org level
# How
- Switch all instances of access keys with a reference to the organization secrets
