### PR TITLE
fix: only authenticate websocket requests when api key auth is enabled

### DIFF
--- a/data-plane/src/server/server.rs
+++ b/data-plane/src/server/server.rs
@@ -171,12 +171,12 @@ async fn handle_websocket_request<S: AsyncRead + AsyncWrite + Unpin>(
 ) {
     let context_builder =
         init_request_context(&request, enclave_context.clone(), feature_context.clone());
-    
+
     if !feature_context.api_key_auth {
-      log_non_http_trx(tx_for_connection, true, remote_ip, Some(context_builder));
-      let serialized_request = request_to_bytes(request).await;
-      let _ = pipe_to_customer_process(stream, &serialized_request, port).await;
-      return;
+        log_non_http_trx(tx_for_connection, true, remote_ip, Some(context_builder));
+        let serialized_request = request_to_bytes(request).await;
+        let _ = pipe_to_customer_process(stream, &serialized_request, port).await;
+        return;
     }
 
     let api_key = match request


### PR DESCRIPTION
# Why

Codepath for handling websockets unconditionally attempted to auth the incoming request, even if the api key auth setting was disabled.

# How

Check if api key auth is disabled before attempting auth. If its disabled, passthrough the req.
