### PR TITLE
chore: bump openssl version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,9 +2396,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -2437,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ members = ["control-plane","data-plane","shared","crates/*"]
 exclude = ["./e2e-tests/mock-crypto"]
 
 [workspace.dependencies]
-openssl = { version = "0.10.60", features = ["vendored"] }
+openssl = { version = "0.10.72", features = ["vendored"] }
 cadence = "1.5.0"
 cadence-macros = "1.5.0"


### PR DESCRIPTION
# Why
Patch openssl version from `0.10.69` to `0.10.72`
