### PR TITLE
feat: expose optional public key parameter on the attestation doc internal endpoint

### DIFF
--- a/data-plane/src/cert_provisioner_client/mod.rs
+++ b/data-plane/src/cert_provisioner_client/mod.rs
@@ -54,7 +54,7 @@ impl CertProvisionerClient {
         let token_bytes = token.as_bytes().to_vec();
 
         #[cfg(feature = "enclave")]
-        let attestation_doc = attest::get_attestation_doc(Some(token_bytes), None)
+        let attestation_doc = attest::get_attestation_doc(Some(token_bytes), None, None) 
             .map_err(|err| CertProvisionerError::General(err.to_string()))?;
 
         #[cfg(not(feature = "enclave"))]

--- a/data-plane/src/cert_provisioner_client/mod.rs
+++ b/data-plane/src/cert_provisioner_client/mod.rs
@@ -54,7 +54,7 @@ impl CertProvisionerClient {
         let token_bytes = token.as_bytes().to_vec();
 
         #[cfg(feature = "enclave")]
-        let attestation_doc = attest::get_attestation_doc(Some(token_bytes), None, None) 
+        let attestation_doc = attest::get_attestation_doc(Some(token_bytes), None, None)
             .map_err(|err| CertProvisionerError::General(err.to_string()))?;
 
         #[cfg(not(feature = "enclave"))]

--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -49,6 +49,8 @@ pub enum CryptoApiError {
     SerializationError,
     #[error("Failed to read context - {0}")]
     ContextError(#[from] ContextError),
+    #[error("Error decoding base64 value — {0}")]
+    DecodeError(#[from] base64::DecodeError),
     #[error("Error — {0:?}")]
     Error(#[from] Error),
 }
@@ -150,7 +152,8 @@ impl CryptoApi {
         let ad_request: AttestationRequest = serde_json::from_value(body)?;
         let challenge = ad_request.challenge.map(|chal| chal.as_bytes().to_vec());
         let nonce = ad_request.nonce.map(|non| non.as_bytes().to_vec());
-        let doc = attest::get_attestation_doc(challenge, nonce)?;
+        let public_key = ad_request.public_key.and_then(|b64_der_encoded_pub_key| base64::decode(b64_der_encoded_pub_key).ok());
+        let doc = attest::get_attestation_doc(challenge, nonce, public_key)?;
         Ok(Body::from(doc))
     }
 
@@ -179,4 +182,5 @@ impl CryptoApi {
 pub struct AttestationRequest {
     nonce: Option<String>,
     challenge: Option<String>,
+    public_key: Option<String>,
 }

--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -152,10 +152,7 @@ impl CryptoApi {
         let ad_request: AttestationRequest = serde_json::from_value(body)?;
         let challenge = ad_request.challenge.map(|chal| chal.as_bytes().to_vec());
         let nonce = ad_request.nonce.map(|non| non.as_bytes().to_vec());
-        let public_key = ad_request
-            .public_key
-            .map(|b64_der_encoded_pub_key| base64::decode(b64_der_encoded_pub_key))
-            .transpose()?;
+        let public_key = ad_request.public_key.map(base64::decode).transpose()?;
         let doc = attest::get_attestation_doc(challenge, nonce, public_key)?;
         Ok(Body::from(doc))
     }

--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -154,7 +154,8 @@ impl CryptoApi {
         let nonce = ad_request.nonce.map(|non| non.as_bytes().to_vec());
         let public_key = ad_request
             .public_key
-            .and_then(|b64_der_encoded_pub_key| base64::decode(b64_der_encoded_pub_key).ok());
+            .map(|b64_der_encoded_pub_key| base64::decode(b64_der_encoded_pub_key))
+            .transpose()?;
         let doc = attest::get_attestation_doc(challenge, nonce, public_key)?;
         Ok(Body::from(doc))
     }

--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -182,6 +182,7 @@ impl CryptoApi {
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AttestationRequest {
     nonce: Option<String>,
     challenge: Option<String>,

--- a/data-plane/src/crypto/api.rs
+++ b/data-plane/src/crypto/api.rs
@@ -152,7 +152,9 @@ impl CryptoApi {
         let ad_request: AttestationRequest = serde_json::from_value(body)?;
         let challenge = ad_request.challenge.map(|chal| chal.as_bytes().to_vec());
         let nonce = ad_request.nonce.map(|non| non.as_bytes().to_vec());
-        let public_key = ad_request.public_key.and_then(|b64_der_encoded_pub_key| base64::decode(b64_der_encoded_pub_key).ok());
+        let public_key = ad_request
+            .public_key
+            .and_then(|b64_der_encoded_pub_key| base64::decode(b64_der_encoded_pub_key).ok());
         let doc = attest::get_attestation_doc(challenge, nonce, public_key)?;
         Ok(Body::from(doc))
     }

--- a/data-plane/src/crypto/attest.rs
+++ b/data-plane/src/crypto/attest.rs
@@ -66,6 +66,7 @@ impl std::convert::From<AttestationError> for hyper::Response<hyper::Body> {
 pub fn get_attestation_doc(
     challenge: Option<Vec<u8>>,
     nonce: Option<Vec<u8>>,
+    public_key: Option<Vec<u8>>,
 ) -> Result<Vec<u8>, AttestationError> {
     let nsm_conn = NsmConnection::try_new()?;
     let nonce = get_nonce(nonce, nsm_conn.fd())?;
@@ -73,7 +74,7 @@ pub fn get_attestation_doc(
     let nsm_request = nitro::api::Request::Attestation {
         user_data: challenge.map(ByteBuf::from),
         nonce: Some(ByteBuf::from(nonce)),
-        public_key: None,
+        public_key: public_key.map(ByteBuf::from),
     };
 
     match nitro::driver::nsm_process_request(nsm_conn.fd(), nsm_request) {

--- a/data-plane/src/crypto/token.rs
+++ b/data-plane/src/crypto/token.rs
@@ -70,7 +70,7 @@ impl TokenClient {
         use crate::crypto::attest;
         use openssl::base64::encode_block;
 
-        let attestation_doc = attest::get_attestation_doc(None, Some(nonce))?;
+        let attestation_doc = attest::get_attestation_doc(None, Some(nonce), None)?;
         Ok(encode_block(&attestation_doc))
     }
 

--- a/data-plane/src/server/layers/attest.rs
+++ b/data-plane/src/server/layers/attest.rs
@@ -83,7 +83,7 @@ where
                 Some(ad) => ad.clone(),
                 None => {
                     let challenge = TRUSTED_PUB_CERT.get();
-                    let doc = match attest::get_attestation_doc(challenge.cloned(), None) {
+                    let doc = match attest::get_attestation_doc(challenge.cloned(), None, None) {
                         Ok(ad) => ad,
                         Err(e) => {
                             log::error!("Failed to generate attestation doc. Error: {:?}", e);

--- a/data-plane/src/server/tls/cert_resolver.rs
+++ b/data-plane/src/server/tls/cert_resolver.rs
@@ -262,7 +262,7 @@ impl AttestableCertResolver {
     ) -> ServerResult<SystemTime> {
         use crate::crypto::attest;
 
-        let attestation_doc = attest::get_attestation_doc(challenge, nonce).unwrap();
+        let attestation_doc = attest::get_attestation_doc(challenge, nonce, None).unwrap();
         let expiry = attest::get_expiry_time(&attestation_doc)?;
         let hex_encoded_ad = shared::utils::HexSlice::from(attestation_doc.as_slice());
         for hostname in hostnames {


### PR DESCRIPTION
# Why

We want to support the generation of attestation documents containing public keys to allow use of the KMS <> Nitro integration.

# How

Include an optional public key argument in the attest endpoint, which is taken as a base64 encoded string. If set, it is provided to the NSM API call as the `public_key` argument.
