### PR TITLE
Fix: remove initial read on egress connections as its no longer needed

### DIFF
--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -66,9 +66,8 @@ impl EgressProxy {
         mut external_stream: TcpStream,
         allowed_domains: EgressDestinations,
     ) -> Result<(), DNSError> {
-        let mut buf = vec![0u8; 4096];
+        let mut buf = [0u8; 4096];
         let n = Self::try_read_with_timeout(&mut external_stream, &mut buf).await?;
-
         let customer_data = &mut buf[..n];
 
         let mut data_plane_stream =

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -183,10 +183,7 @@ mod tests {
             allow_all: true,
             ips: vec![],
         };
-        assert_eq!(
-            check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).unwrap(),
-            ()
-        );
+        assert!(check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).is_ok());
     }
     #[test]
     fn test_valid_exact_domain() {
@@ -196,10 +193,7 @@ mod tests {
             allow_all: false,
             ips: vec![],
         };
-        assert_eq!(
-            check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).unwrap(),
-            ()
-        );
+        assert!(check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).is_ok());
     }
     #[test]
     fn test_valid_wildcard_domain() {
@@ -209,10 +203,7 @@ mod tests {
             allow_all: false,
             ips: vec![],
         };
-        assert_eq!(
-            check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).unwrap(),
-            ()
-        );
+        assert!(check_domain_allow_list("app.evervault.com".to_string(), &egress_domains).is_ok());
     }
     #[test]
     fn test_invalid_domain() {

--- a/data-plane/src/dns/egressproxy.rs
+++ b/data-plane/src/dns/egressproxy.rs
@@ -47,13 +47,9 @@ impl EgressProxy {
     }
 
     async fn handle_egress_connection(
-        mut external_stream: TcpStream,
+        external_stream: TcpStream,
         allowed_domains: EgressDestinations,
     ) -> Result<(), DNSError> {
-        let mut buf = vec![0u8; 4096];
-        let n = external_stream.read(&mut buf).await?;
-        let customer_data = &mut buf[..n];
-
         let mut data_plane_stream =
             Bridge::get_client_connection(EGRESS_PROXY_VSOCK_PORT, Direction::EnclaveToHost)
                 .await?;
@@ -63,7 +59,7 @@ impl EgressProxy {
 
         let external_request = ExternalRequest {
             ip,
-            data: customer_data.to_vec(),
+            data: vec![],
             port,
         }
         .to_bytes()?;


### PR DESCRIPTION
# Why

The in-Enclave egress proxy attempted to read an initial packet before forwarding the egress target details to the host. This was leftover from an initial assumption that the connection would be TLS encrypted, however this is likely now causing issues for non-HTTPS egress.

For example, MySQL clients expect a packet to be sent by the server before the client will send any data. When put through this code path, the egress connection hangs indefinitely waiting for data from the client.

# How

Use read with timeout on incoming sockets. Send egress packet to host to open connection to remote, before piping the connection in both directions.
