### PR TITLE
Use Github Actions OICD Role instead of AWS Access Keys

### DIFF
--- a/.github/workflows/deploy-control-plane-image-production.yml
+++ b/.github/workflows/deploy-control-plane-image-production.yml
@@ -6,6 +6,9 @@ on:
 name: Deploy new control plane image to production
 env:
   LINUX_TARGET: x86_64-unknown-linux-musl
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   get-version:
@@ -56,10 +59,9 @@ jobs:
       - name: Move control-plane binary to root
         run: cp ./target/${{ env.LINUX_TARGET }}/release/control-plane ./control-plane
       - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -100,10 +102,9 @@ jobs:
       - name: Move control-plane binary to root
         run: cp ./target/${{ env.LINUX_TARGET }}/release/control-plane ./control-plane
       - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -138,10 +139,9 @@ jobs:
 
     steps:
       - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy-control-plane-image-staging.yml
+++ b/.github/workflows/deploy-control-plane-image-staging.yml
@@ -11,6 +11,10 @@ on:
 name: Deploy new control plane image
 env:
   LINUX_TARGET: x86_64-unknown-linux-musl
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   last_test:
     runs-on: ubuntu-latest
@@ -76,10 +80,9 @@ jobs:
       - name: Move control-plane binary to root
         run: cp ./target/${{ env.LINUX_TARGET }}/release/control-plane ./control-plane
       - name: Configure Staging AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr
@@ -124,10 +127,9 @@ jobs:
       - name: Move control-plane binary to root
         run: cp ./target/${{ env.LINUX_TARGET }}/release/control-plane ./control-plane
       - name: Configure Staging AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
           aws-region: us-east-1
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy-data-plane-binary-production.yml
+++ b/.github/workflows/deploy-data-plane-binary-production.yml
@@ -1,4 +1,4 @@
-name: Release data-plane binary production
+name: Deploy new data plane binary to production
 
 on:
   push:
@@ -9,6 +9,9 @@ env:
   RUST_BACKTRACE: 1
   LINUX_TARGET: x86_64-unknown-linux-musl
   STAGE: production
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   get-version:
@@ -32,10 +35,9 @@ jobs:
           sh ./scripts/insert-data-plane-version.sh ${{ needs.get-version.outputs.version }}
 
       - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
           aws-region: us-east-1
 
       - uses: Swatinem/rust-cache@v2
@@ -103,10 +105,9 @@ jobs:
           ]
     steps:
       - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
           aws-region: us-east-1
 
       - name: Upload data-plane to S3 (${{ matrix.feature }})
@@ -128,10 +129,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
           aws-region: us-east-1
 
       - name: Upload version tag to latest

--- a/.github/workflows/deploy-data-plane-binary-staging.yml
+++ b/.github/workflows/deploy-data-plane-binary-staging.yml
@@ -1,4 +1,4 @@
-name: Release data-plane binary staging
+name: Deploy new data plane binary to staging
 
 on:
   push:
@@ -13,6 +13,9 @@ env:
   RUST_BACKTRACE: 1
   LINUX_TARGET: x86_64-unknown-linux-musl
   STAGE: staging
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   get-release-semver:
@@ -54,10 +57,9 @@ jobs:
           targets: x86_64-unknown-linux-musl
 
       - name: Configure Staging AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
+          role-to-assume: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
           aws-region: us-east-1
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy-runtime-installer-production.yml
+++ b/.github/workflows/deploy-runtime-installer-production.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "installer/v*.*.*"
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   get-version:
@@ -23,6 +26,6 @@ jobs:
       stage: "production"
       version: ${{ needs.get-version.outputs.version }}
     secrets:
-      aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY }}
+      ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
+      ENCLAVES_PUBLIC_AWS_ROLE_STAGING: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
       aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }}

--- a/.github/workflows/deploy-runtime-installer-staging.yml
+++ b/.github/workflows/deploy-runtime-installer-staging.yml
@@ -6,6 +6,9 @@ on:
       - "installer/**"
     branches:
       - "main"
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build-and-deploy:
@@ -14,6 +17,6 @@ jobs:
       stage: "staging"
       version: 1
     secrets:
-      aws-access-key-id: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_KEY_ID_STAGING }}
-      aws-secret-access-key: ${{ secrets.ENCLAVES_PUBLIC_AWS_ACCESS_SECRET_KEY_STAGING }}
+      ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION }}
+      ENCLAVES_PUBLIC_AWS_ROLE_STAGING: ${{ secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
       aws-cloudfront-distribution-id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_STAGING }}

--- a/.github/workflows/deploy-runtime-installer.yml
+++ b/.github/workflows/deploy-runtime-installer.yml
@@ -12,10 +12,13 @@ on:
     secrets:
       aws-cloudfront-distribution-id:
         required: true
-      aws-access-key-id:
+      ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION:
         required: true
-      aws-secret-access-key:
+      ENCLAVES_PUBLIC_AWS_ROLE_STAGING:
         required: true
+permissions:
+  id-token: write
+  contents: read
 jobs:
   build-runtime-bundle:
     runs-on: ubuntu-latest
@@ -42,11 +45,10 @@ jobs:
       - uses: actions/download-artifact@v4.1.7
         with:
           name: runtime-dependencies-${{github.sha}}.zip
-      - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          role-to-assume: ${{ inputs.stage == 'production' && secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION || secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
           aws-region: us-east-1
       - name: Upload installer bundle to S3
         env:
@@ -59,11 +61,10 @@ jobs:
     needs: [build-runtime-bundle, upload-runtime-bundle]
     steps:
       - uses: actions/checkout@v4
-      - name: Configure Production AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          role-to-assume: ${{ inputs.stage == 'production' && secrets.ENCLAVES_PUBLIC_AWS_ROLE_PRODUCTION || secrets.ENCLAVES_PUBLIC_AWS_ROLE_STAGING }}
           aws-region: us-east-1
       - name: Update latest record for installer
         env:


### PR DESCRIPTION
# Why
Use Github Actions OICD AWS Role instead of AWS Access Keys
