### PR TITLE
chore: set version output correctly, replace length based prefix strip

### DIFF
--- a/.github/workflows/publish-storage-client-interface.yml
+++ b/.github/workflows/publish-storage-client-interface.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Get version from tag
         id: get-version
         run: |
-          echo "using version tag ${GITHUB_REF:36}"
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "using version tag ${TAG#storage-client-interface/v}"
+          echo "version=${TAG#storage-client-interface/v}" >> $GITHUB_OUTPUT
   assert-matching-version:
     runs-on: ubuntu-latest
     needs: [get-version]


### PR DESCRIPTION
# Why

version from tag wasn't correctly set as output on the get-version step causing the release workflow to fail

# How

Set the output correctly, remove constant length based prefix logic.