### PR TITLE
fix: use github action sub syntax for output version

### DIFF
--- a/.github/workflows/publish-storage-client-interface.yml
+++ b/.github/workflows/publish-storage-client-interface.yml
@@ -30,9 +30,9 @@ jobs:
         id: get-cargo-version
         run: |
           CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq '.packages[] | select( .name == "storage-client-interface" ) | .version' | tr -d '"')
-          if [ "$CARGO_VERSION" != "${needs.get-version.outputs.version}" ]; then
+          if [ "$CARGO_VERSION" != "${{ needs.get-version.outputs.version }}" ]; then
             echo "Version in tag does not match cargo.toml"
-            echo "Expected $CARGO_VERSION, Found ${needs.get-version.outputs.version}"
+            echo "Expected $CARGO_VERSION, Found ${{ needs.get-version.outputs.version }}"
             exit 1
           fi
 


### PR DESCRIPTION
# Why

Incorrect syntax for substituting output from previous step is causing the release to fail

# How

Use double braces