### PR TITLE
chore: rework update fd limit to try to raise to sys limit, falling back to proc hardlimit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,9 +2145,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linked-hash-map"
@@ -2870,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
 dependencies = [
  "libc",
 ]

--- a/crates/data-plane/Cargo.toml
+++ b/crates/data-plane/Cargo.toml
@@ -54,7 +54,7 @@ httparse = "1.8.0"
 mockall = "0.11.4"
 uuid = { version = "1.4.1", features = ["v4"] }
 log = { version = "0.4.19", features = ["max_level_debug"] }
-rlimit = { version = "0.10.1", optional = true }
+rlimit = { version = "0.11", optional = true }
 hyper-rustls = { version = "0.24.1", default-features = false, features = [
   "http1",
   "http2",

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -62,8 +62,8 @@ fn main() {
 
     #[cfg(feature = "enclave")]
     {
-      try_update_fd_limit();
-      try_show_fd_limits();
+        try_update_fd_limit();
+        try_show_fd_limits();
     }
 
     let mut args = std::env::args();

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -22,29 +22,36 @@ use tokio::sync::mpsc::Sender;
 use tokio::time::Duration;
 
 #[cfg(feature = "enclave")]
-fn try_update_fd_limit() {
-    match std::fs::read_to_string("/proc/sys/fs/nr_open")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-    {
-        Some(nr_open) => {
-            if let Err(e) = rlimit::setrlimit(rlimit::Resource::NOFILE, nr_open, nr_open) {
-                eprintln!(
-                    "Failed to set enclave file descriptor limit on startup (requested {nr_open}) - {e:?}"
-                );
-            }
-        }
-        None => {
-            eprintln!("Failed to read /proc/sys/fs/nr_open - clamping softlimit to proc hardlimit");
-            if let Err(e) = rlimit::increase_nofile_limit(rlimit::INFINITY) {
-                eprintln!("Failed to clamp softlimit to proc hardlimit - {e}")
-            }
-        }
-    }
-
+fn try_show_fd_limits() {
     if let Ok((soft_limit, hard_limit)) = rlimit::getrlimit(rlimit::Resource::NOFILE) {
         println!("RLIMIT_NOFILE: SoftLimit={soft_limit}, HardLimit={hard_limit}");
     }
+}
+
+#[cfg(feature = "enclave")]
+fn apply_clamped_limit() {
+    if let Err(e) = rlimit::increase_nofile_limit(rlimit::INFINITY) {
+        eprintln!("Failed to clamp softlimit to proc hardlimit - {e}")
+    }
+}
+
+#[cfg(feature = "enclave")]
+fn try_update_fd_limit() {
+    let sys_fd_lim = std::fs::read_to_string("/proc/sys/fs/nr_open")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok());
+
+    let Some(nr_open) = sys_fd_lim else {
+        apply_clamped_limit();
+        return;
+    };
+
+    if let Err(e) = rlimit::setrlimit(rlimit::Resource::NOFILE, nr_open, nr_open) {
+        eprintln!(
+            "Failed to set enclave file descriptor limit on startup (requested {nr_open}) - {e:?}"
+        );
+        apply_clamped_limit();
+    };
 }
 
 const ENCLAVE_CLOCK_SYNC_INTERVAL: Duration = Duration::from_secs(300);
@@ -54,7 +61,10 @@ fn main() {
     print_version!("Data Plane");
 
     #[cfg(feature = "enclave")]
-    try_update_fd_limit();
+    {
+      try_update_fd_limit();
+      try_show_fd_limits();
+    }
 
     let mut args = std::env::args();
     let _ = args.next(); // ignore path to executable

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -22,10 +22,26 @@ use tokio::sync::mpsc::Sender;
 use tokio::time::Duration;
 
 #[cfg(feature = "enclave")]
-fn try_update_fd_limit(soft_limit: u64, hard_limit: u64) {
-    if let Err(e) = rlimit::setrlimit(rlimit::Resource::NOFILE, soft_limit, hard_limit) {
-        eprintln!("Failed to set enclave file descriptor limit on startup - {e:?}");
+fn try_update_fd_limit() {
+    match std::fs::read_to_string("/proc/sys/fs/nr_open")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+    {
+        Some(nr_open) => {
+            if let Err(e) = rlimit::setrlimit(rlimit::Resource::NOFILE, nr_open, nr_open) {
+                eprintln!(
+                    "Failed to set enclave file descriptor limit on startup (requested {nr_open}) - {e:?}"
+                );
+            }
+        }
+        None => {
+            eprintln!("Failed to read /proc/sys/fs/nr_open - clamping softlimit to proc hardlimit");
+            if let Err(e) = rlimit::increase_nofile_limit(rlimit::INFINITY) {
+                eprintln!("Failed to clamp softlimit to proc hardlimit - {e}")
+            }
+        }
     }
+
     if let Ok((soft_limit, hard_limit)) = rlimit::getrlimit(rlimit::Resource::NOFILE) {
         println!("RLIMIT_NOFILE: SoftLimit={soft_limit}, HardLimit={hard_limit}");
     }
@@ -38,7 +54,7 @@ fn main() {
     print_version!("Data Plane");
 
     #[cfg(feature = "enclave")]
-    try_update_fd_limit(rlimit::INFINITY, rlimit::INFINITY);
+    try_update_fd_limit();
 
     let mut args = std::env::args();
     let _ = args.next(); // ignore path to executable


### PR DESCRIPTION
# Why

Attempt to raise fd limit on boot was failing due to limits exceeding the permitted upper bound. This meant that the call failed outright and defaults never moved.

# How

- Attempt to set limits to sys limit
- If we fail to set to sys limit, fallback to `rlimit`'s `increase_nofile_limit` which will clamp infinity to the hard limit of the current process