### PR TITLE
perf(data-plane): run TLS handshakes off the accept loop

### DIFF
--- a/crates/data-plane/src/server/server.rs
+++ b/crates/data-plane/src/server/server.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::time::{timeout, Duration};
 use tokio_rustls::server::TlsStream;
 use tower::Service;
 
@@ -29,6 +30,11 @@ use super::layers::{
     decrypt::DecryptLayer,
     forward::ForwardService,
 };
+
+/// Maximum time allowed for a single TLS handshake. Bounds slow/stalled clients (slowloris): a
+/// connection that opens but never completes the handshake is dropped instead of holding a task and
+/// socket open indefinitely.
+const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub async fn run<L: Listener + Send + Sync>(
     tcp_server: L,
@@ -87,24 +93,42 @@ where
         )
         .layer(DecryptLayer::new(e3_client.clone()))
         .service(ForwardService);
+
     loop {
-        let mut stream = match server.accept().await {
-            Ok(stream) => stream,
-            Err(tls_err) => {
+        // Accept the connection here (fast — drains the bridge listen backlog) but defer the TLS
+        // handshake into the spawned task below, so handshakes run concurrently instead of
+        // serializing the accept loop. A serial inline handshake capped accepts and saturated the
+        // backlog, which in turn capped the number of concurrent connections.
+        let pending = match server.accept_pending().await {
+            Ok(pending) => pending,
+            Err(err) => {
                 log::error!(
-                    "An error occurred while accepting the incoming connection — {tls_err}"
+                    "An error occurred while accepting the incoming connection — {err}"
                 );
                 continue;
             }
         };
 
-        let remote_ip = stream.get_remote_addr().clone();
         let tx_for_connection = tx.clone();
         let mut data_plane_service = service.clone();
         let enclave_context_clone = enclave_context.clone();
         let feature_context_clone = feature_context.clone();
         let e3_client_clone = e3_client.clone();
         tokio::spawn(async move {
+            // Bound the handshake: a client that connects but stalls mid-TLS (slowloris) must not
+            // be able to hold the task and socket open indefinitely.
+            let mut stream = match timeout(TLS_HANDSHAKE_TIMEOUT, pending.finish()).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(tls_err)) => {
+                    log::error!("An error occurred during the TLS handshake — {tls_err}");
+                    return;
+                }
+                Err(_) => {
+                    log::error!("TLS handshake timed out after {TLS_HANDSHAKE_TIMEOUT:?}");
+                    return;
+                }
+            };
+            let remote_ip = stream.get_remote_addr().clone();
             loop {
                 match try_parse_http_request_from_stream(&mut stream, port).await {
                     Ok(Incoming::HttpRequest(request)) if parse::is_websocket_request(&request) => {

--- a/crates/data-plane/src/server/tls/tls_server.rs
+++ b/crates/data-plane/src/server/tls/tls_server.rs
@@ -1,11 +1,8 @@
-use async_trait::async_trait;
-
 #[cfg(feature = "enclave")]
 use once_cell::sync::OnceCell;
 #[cfg(feature = "enclave")]
 use tokio_rustls::rustls::sign::CertifiedKey;
 
-use shared::server::proxy_protocol::ProxiedConnection;
 use shared::server::Listener;
 use std::sync::Arc;
 use tokio_rustls::rustls::server::WantsServerCert;
@@ -116,17 +113,41 @@ async fn enclave_trusted_cert() -> Option<CertifiedKey> {
     }
 }
 
-#[async_trait]
-impl<S: Listener + Send + Sync> Listener for TlsServer<S>
+/// A connection that has been accepted but not yet TLS-terminated.
+///
+/// Accept and handshake are split (see [`TlsServer::accept_pending`]) so the accept loop can drain
+/// the bridge listen backlog quickly and run handshakes concurrently in spawned tasks, rather than
+/// serializing every handshake inside the accept loop. A [`TlsStream`] can only be obtained via
+/// [`PendingTls::finish`], so a not-yet-terminated connection cannot be mistaken for a ready,
+/// encrypted stream.
+pub struct PendingTls<C> {
+    conn: C,
+    acceptor: TlsAcceptor,
+}
+
+impl<C> PendingTls<C>
 where
-    TlsError: From<<S as Listener>::Error>,
-    <S as Listener>::Connection: ProxiedConnection,
+    C: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    type Connection = TlsStream<<S as Listener>::Connection>;
-    type Error = TlsError;
-    async fn accept(&mut self) -> Result<Self::Connection, Self::Error> {
+    /// Perform the TLS handshake, producing the terminated stream. Callers should wrap this in a
+    /// timeout (see `server::run`) so a client that stalls mid-handshake cannot hold the
+    /// connection open indefinitely.
+    pub async fn finish(self) -> Result<TlsStream<C>, TlsError> {
+        Ok(self.acceptor.accept(self.conn).await?)
+    }
+}
+
+impl<S: Listener + Send + Sync> TlsServer<S> {
+    /// Accept the next connection and return a handle whose [`PendingTls::finish`] performs the TLS
+    /// handshake. Splitting accept from handshake keeps the accept loop non-blocking; the caller
+    /// runs `finish()` in a spawned task. See `server::run`.
+    pub async fn accept_pending(
+        &mut self,
+    ) -> Result<PendingTls<<S as Listener>::Connection>, <S as Listener>::Error> {
         let conn = self.inner.accept().await?;
-        let accepted_tls_conn = self.tls_acceptor.accept(conn).await?;
-        Ok(accepted_tls_conn)
+        Ok(PendingTls {
+            conn,
+            acceptor: self.tls_acceptor.clone(),
+        })
     }
 }


### PR DESCRIPTION
# Why
The accept loop terminated TLS inline before returning, so handshakes were serialized: the loop could not accept the next connection until the current handshake completed. Under connection load this throttled the accept rate and saturated the listen backlog, capping concurrent connections.

Accept the raw connection in the loop and perform the handshake inside the spawned task instead, so handshakes proceed concurrently. A PendingTls handle carries the accepted-but-not-terminated connection; its finish() performs the handshake and is the only way to obtain a TlsStream, so a non-terminated connection cannot be mistaken for a ready stream.

Wrap the handshake in a 10s timeout so a client that stalls mid-handshake cannot hold the task and socket open indefinitely.

Remove the now-unused Listener impl on TlsServer (its inline TCP+TLS accept is no longer used).
