### PR TITLE
Add test harness for enclaves repo and refactor listener to support concurrent TLS handshakes

### DIFF
--- a/crates/data-plane/Cargo.toml
+++ b/crates/data-plane/Cargo.toml
@@ -72,6 +72,7 @@ regex = "1.10.6"
 [dev-dependencies]
 tokio-test = "0.4.2"
 yup-hyper-mock = "6.0.0"
+tokio = { version = "1.43.1", features = ["test-util"] }
 
 [features]
 default = ["tls_termination"]

--- a/crates/data-plane/src/lib.rs
+++ b/crates/data-plane/src/lib.rs
@@ -27,6 +27,8 @@ pub mod utils;
 use shared::server::egress::EgressConfig;
 #[cfg(feature = "tls_termination")]
 pub mod server;
+#[cfg(feature = "tls_termination")]
+use server::config::AcceptorConfig;
 
 use shared::server::config_server::requests::ProvisionerContext;
 use thiserror::Error;
@@ -164,6 +166,9 @@ pub struct FeatureContext {
     pub attestation_cors: Option<AttestationCors>,
     #[cfg(feature = "network_egress")]
     pub egress: EgressConfig,
+    #[cfg(feature = "tls_termination")]
+    #[serde(default)]
+    pub acceptor: AcceptorConfig,
 }
 
 impl FeatureContext {
@@ -230,6 +235,31 @@ mod test {
         assert!(feature_context.attestation_cors.is_none());
     }
 
+    #[cfg(all(feature = "tls_termination", not(feature = "network_egress")))]
+    #[test]
+    fn test_acceptor_absent_defaults_to_serial() {
+        let raw_feature_context = r#"{ "api_key_auth": false, "trx_logging_enabled": false, "forward_proxy_protocol": false, "trusted_headers": [] }"#;
+        let feature_context: FeatureContext = serde_json::from_str(raw_feature_context).unwrap();
+        assert!(feature_context.acceptor.is_serial());
+        assert_eq!(feature_context.acceptor.max_concurrent_connections, 1);
+        assert_eq!(feature_context.acceptor.max_concurrent_handshakes, 1);
+        assert!(feature_context.acceptor.handshake_timeout.is_none());
+    }
+
+    #[cfg(all(feature = "tls_termination", not(feature = "network_egress")))]
+    #[test]
+    fn test_acceptor_block_parses_all_three_fields() {
+        let raw_feature_context = r#"{ "api_key_auth": false, "trx_logging_enabled": false, "forward_proxy_protocol": false, "trusted_headers": [], "acceptor": { "max_concurrent_connections": 1024, "max_concurrent_handshakes": 64, "handshake_timeout": { "secs": 10, "nanos": 0 } } }"#;
+        let feature_context: FeatureContext = serde_json::from_str(raw_feature_context).unwrap();
+        assert_eq!(feature_context.acceptor.max_concurrent_connections, 1024);
+        assert_eq!(feature_context.acceptor.max_concurrent_handshakes, 64);
+        assert_eq!(
+            feature_context.acceptor.handshake_timeout,
+            Some(std::time::Duration::from_secs(10))
+        );
+        assert!(!feature_context.acceptor.is_serial());
+    }
+
     #[cfg(feature = "network_egress")]
     #[test]
     fn test_config_deserialization_with_egress() {
@@ -268,5 +298,24 @@ mod test {
             vec![".stripe.com".to_string()]
         );
         assert_eq!(feature_context.healthcheck, Some("/health".into()));
+    }
+
+    #[cfg(all(feature = "tls_termination", feature = "network_egress"))]
+    #[test]
+    fn test_acceptor_block_parses_alongside_egress() {
+        let raw_feature_context = r#"{ "api_key_auth": false, "egress": { "allow_list": "jsonplaceholder.typicode.com" }, "trx_logging_enabled": true, "forward_proxy_protocol": false, "trusted_headers": [], "acceptor": { "max_concurrent_connections": 1024, "max_concurrent_handshakes": 64, "handshake_timeout": { "secs": 10, "nanos": 0 } } }"#;
+        let feature_context: FeatureContext =
+            serde_json::from_str(raw_feature_context).expect("e2e config shape must parse");
+        assert_eq!(feature_context.acceptor.max_concurrent_connections, 1024);
+        assert_eq!(feature_context.acceptor.max_concurrent_handshakes, 64);
+        assert_eq!(
+            feature_context.acceptor.handshake_timeout,
+            Some(std::time::Duration::from_secs(10))
+        );
+        assert!(!feature_context.acceptor.is_serial());
+        assert_eq!(
+            feature_context.egress.allow_list.exact,
+            vec!["jsonplaceholder.typicode.com".to_string()]
+        );
     }
 }

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -14,9 +14,7 @@ use shared::server::Listener;
 use shared::{
     bridge::{Bridge, BridgeInterface, Direction},
     notify_shutdown::{NotifyShutdown, Service},
-    print_version,
-    server::proxy_protocol::ProxyProtocolServer,
-    ENCLAVE_CONNECT_PORT,
+    print_version, ENCLAVE_CONNECT_PORT,
 };
 use tokio::sync::mpsc::Sender;
 use tokio::time::Duration;
@@ -175,7 +173,7 @@ async fn start_data_plane(
 ) {
     log::info!("Data plane starting up. Forwarding traffic to {data_plane_port}");
     let server = match Bridge::get_listener(ENCLAVE_CONNECT_PORT, Direction::EnclaveToHost).await {
-        Ok(server) => ProxyProtocolServer::from(server),
+        Ok(server) => server,
         Err(error) => return log::error!("Error creating server: {error}"),
     };
     log::debug!("Data plane TCP server created");
@@ -191,7 +189,10 @@ async fn start_data_plane(
 #[cfg(not(feature = "tls_termination"))]
 use data_plane::env::Finalize;
 #[cfg(not(feature = "tls_termination"))]
-use shared::{server::proxy_protocol::ProxiedConnection, utils::pipe_streams};
+use shared::{
+    server::proxy_protocol::{ProxiedConnection, ProxyProtocolServer},
+    utils::pipe_streams,
+};
 #[cfg(not(feature = "tls_termination"))]
 use tokio::io::AsyncWriteExt;
 #[cfg(not(feature = "tls_termination"))]

--- a/crates/data-plane/src/server/config.rs
+++ b/crates/data-plane/src/server/config.rs
@@ -1,15 +1,25 @@
 use std::time::Duration;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct AcceptorConfig {
+    #[serde(deserialize_with = "deserialize_min_one")]
     pub max_concurrent_connections: usize,
     // Maximum connections allowed in the TLS handshake phase. Tracked separately from total
     // connections because the handshake is the expensive bit
+    #[serde(deserialize_with = "deserialize_min_one")]
     pub max_concurrent_handshakes: usize,
     pub handshake_timeout: Option<Duration>,
+}
+
+fn deserialize_min_one<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    Ok(value.max(1))
 }
 
 impl Default for AcceptorConfig {
@@ -119,6 +129,18 @@ mod test {
         let raw = r#"{ "max_concurrent_connections": 512 }"#;
         let config: AcceptorConfig = serde_json::from_str(raw).unwrap();
         assert_eq!(config.max_concurrent_connections, 512);
+        assert_eq!(config.max_concurrent_handshakes, 1);
+        assert!(config.handshake_timeout.is_none());
+    }
+
+    #[test]
+    fn explicit_zero_for_max_connections_is_rejected() {
+        let raw = r#"{
+          "max_concurrent_connections": 0,
+          "max_concurrent_handshakes": 0
+        }"#;
+        let config: AcceptorConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(config.max_concurrent_connections, 1);
         assert_eq!(config.max_concurrent_handshakes, 1);
         assert!(config.handshake_timeout.is_none());
     }

--- a/crates/data-plane/src/server/config.rs
+++ b/crates/data-plane/src/server/config.rs
@@ -1,0 +1,113 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct AcceptorConfig {
+    pub max_concurrent_connections: usize,
+    // Maximum connections allowed in the TLS handshake phase. Tracked separately from total
+    // connections because the handshake is the expensive bit
+    pub max_concurrent_handshakes: usize,
+    pub handshake_timeout: Option<Duration>,
+}
+
+impl Default for AcceptorConfig {
+    // The default is to process requests in series to match the current behavior.
+    // This makes the concurrent behavior opt-in
+    fn default() -> Self {
+        Self {
+            max_concurrent_connections: 1,
+            max_concurrent_handshakes: 1,
+            handshake_timeout: None,
+        }
+    }
+}
+
+impl AcceptorConfig {
+    pub fn serial_compat() -> Self {
+        Self::default()
+    }
+
+    pub fn concurrent_default() -> Self {
+        Self {
+            max_concurrent_connections: 1024,
+            max_concurrent_handshakes: 64,
+            handshake_timeout: Some(Duration::from_secs(10)),
+        }
+    }
+
+    pub fn is_serial(&self) -> bool {
+        self.max_concurrent_connections <= 1 && self.max_concurrent_handshakes <= 1
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn default_is_serial_profile() {
+        let config = AcceptorConfig::default();
+        assert_eq!(config.max_concurrent_connections, 1);
+        assert_eq!(config.max_concurrent_handshakes, 1);
+        assert!(config.handshake_timeout.is_none());
+        assert!(config.is_serial());
+    }
+
+    #[test]
+    fn serial_compat_matches_default() {
+        let serial = AcceptorConfig::serial_compat();
+        let default = AcceptorConfig::default();
+        assert_eq!(
+            serial.max_concurrent_connections,
+            default.max_concurrent_connections
+        );
+        assert_eq!(
+            serial.max_concurrent_handshakes,
+            default.max_concurrent_handshakes
+        );
+        assert_eq!(serial.handshake_timeout, default.handshake_timeout);
+    }
+
+    #[test]
+    fn concurrent_default_is_concurrent() {
+        let config = AcceptorConfig::concurrent_default();
+        assert!(config.max_concurrent_connections > 1);
+        assert!(config.max_concurrent_handshakes > 1);
+        assert!(config.handshake_timeout.is_some());
+        assert!(!config.is_serial());
+    }
+
+    #[test]
+    fn absent_block_deserialises_to_serial_default() {
+        let config: AcceptorConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.is_serial());
+        assert_eq!(config.max_concurrent_connections, 1);
+        assert_eq!(config.max_concurrent_handshakes, 1);
+        assert!(config.handshake_timeout.is_none());
+    }
+
+    #[test]
+    fn full_block_deserialises_all_three_fields() {
+        let raw = r#"{
+            "max_concurrent_connections": 1024,
+            "max_concurrent_handshakes": 64,
+            "handshake_timeout": { "secs": 10, "nanos": 0 }
+        }"#;
+        let config: AcceptorConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(config.max_concurrent_connections, 1024);
+        assert_eq!(config.max_concurrent_handshakes, 64);
+        assert_eq!(config.handshake_timeout, Some(Duration::from_secs(10)));
+        assert!(!config.is_serial());
+    }
+
+    #[test]
+    fn partial_block_keeps_serial_defaults_for_absent_fields() {
+        let raw = r#"{ "max_concurrent_connections": 512 }"#;
+        let config: AcceptorConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(config.max_concurrent_connections, 512);
+        assert_eq!(config.max_concurrent_handshakes, 1);
+        assert!(config.handshake_timeout.is_none());
+    }
+}

--- a/crates/data-plane/src/server/config.rs
+++ b/crates/data-plane/src/server/config.rs
@@ -38,7 +38,9 @@ impl AcceptorConfig {
     }
 
     pub fn is_serial(&self) -> bool {
-        self.max_concurrent_connections <= 1 && self.max_concurrent_handshakes <= 1
+        self.max_concurrent_connections <= 1
+            && self.max_concurrent_handshakes <= 1
+            && self.handshake_timeout.is_none()
     }
 }
 
@@ -99,6 +101,16 @@ mod test {
         assert_eq!(config.max_concurrent_connections, 1024);
         assert_eq!(config.max_concurrent_handshakes, 64);
         assert_eq!(config.handshake_timeout, Some(Duration::from_secs(10)));
+        assert!(!config.is_serial());
+    }
+
+    #[test]
+    fn handshake_timeout_alone_makes_config_non_serial() {
+        let config = AcceptorConfig {
+            max_concurrent_connections: 1,
+            max_concurrent_handshakes: 1,
+            handshake_timeout: Some(Duration::from_secs(10)),
+        };
         assert!(!config.is_serial());
     }
 

--- a/crates/data-plane/src/server/e2e_support.rs
+++ b/crates/data-plane/src/server/e2e_support.rs
@@ -1,0 +1,344 @@
+#![allow(dead_code)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio_rustls::client::TlsStream as ClientTlsStream;
+use tokio_rustls::rustls::client::{ServerCertVerified, ServerCertVerifier};
+use tokio_rustls::rustls::{Certificate, ClientConfig, Error as RustlsError, ServerName};
+use tokio_rustls::TlsConnector;
+
+use shared::server::TcpServer;
+
+use crate::e3client::E3Client;
+use crate::server::config::AcceptorConfig;
+use crate::server::handshake::TlsHandshaker;
+use crate::server::layers::context_log::ContextLogLayer;
+use crate::server::layers::decrypt::DecryptLayer;
+use crate::server::layers::forward::ForwardService;
+use crate::server::metrics::AcceptMetrics;
+use crate::server::server::run_with;
+use crate::server::test_support::fake_feature_context;
+use crate::server::tls::test_certs::test_tls_acceptor;
+use crate::{EnclaveContext, FeatureContext};
+
+use crate::server::layers::auth::AuthLayer;
+
+// ---------------------------------------------------------------------------
+// Globals
+// ---------------------------------------------------------------------------
+
+/// Seed the process-global `EnclaveContext`. The set is `get_or_init` (first
+/// writer wins, process-wide), so these values **must match** the cert-resolver
+/// tests' `init_context` to avoid cross-test contamination — whichever
+/// `#[serial]` test runs first fixes the context for the whole binary.
+pub fn seed_enclave_context() {
+    EnclaveContext::set(EnclaveContext::new(
+        "app_123".into(),
+        "team_456".into(),
+        "enclave_123".into(),
+        "my-sick-enclave".into(),
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// TLS client
+// ---------------------------------------------------------------------------
+
+/// Client-side verifier that trusts any server cert. Identity in this product
+/// comes from attestation, not the TLS PKI; for tests we only care that the
+/// real handshake + data path work (mirrors the repo's `OpenServerCertVerifier`).
+struct AcceptAnyServerCert;
+
+impl ServerCertVerifier for AcceptAnyServerCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+pub fn test_tls_connector() -> TlsConnector {
+    let config = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyServerCert))
+        .with_no_client_auth();
+    TlsConnector::from(Arc::new(config))
+}
+
+/// TCP-connect, optionally write a raw prefix (e.g. a PROXY v2 header) before
+/// the TLS `ClientHello`, then complete the TLS handshake.
+pub async fn connect_tls_with_prefix(
+    addr: SocketAddr,
+    raw_prefix: Option<&[u8]>,
+) -> ClientTlsStream<TcpStream> {
+    let mut tcp = TcpStream::connect(addr).await.expect("tcp connect");
+    if let Some(prefix) = raw_prefix {
+        tcp.write_all(prefix).await.expect("write raw prefix");
+    }
+    let connector = test_tls_connector();
+    // Any non-nonce, non-trusted DNS name resolves to the base attestable cert.
+    let domain = ServerName::try_from("data-plane.local").expect("valid server name");
+    connector.connect(domain, tcp).await.expect("tls handshake")
+}
+
+pub async fn connect_tls(addr: SocketAddr) -> ClientTlsStream<TcpStream> {
+    connect_tls_with_prefix(addr, None).await
+}
+
+/// Read from `stream` until EOF or an idle gap (no bytes for `idle`). Used to
+/// collect a complete HTTP response over a keep-alive connection (which the
+/// server holds open after responding).
+pub async fn read_until_idle<S: AsyncReadExt + Unpin>(stream: &mut S, idle: Duration) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match tokio::time::timeout(idle, stream.read(&mut chunk)).await {
+            Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+            Ok(Ok(n)) => buf.extend_from_slice(&chunk[..n]),
+        }
+    }
+    buf
+}
+
+/// One-shot: open a TLS connection, send `request`, return the response bytes.
+pub async fn request_response(addr: SocketAddr, request: &[u8]) -> Vec<u8> {
+    let mut stream = connect_tls(addr).await;
+    stream.write_all(request).await.expect("write request");
+    read_until_idle(&mut stream, Duration::from_millis(300)).await
+}
+
+// ---------------------------------------------------------------------------
+// Fake customer process
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub enum CustomerMode {
+    /// Echo every byte back (for non-HTTP / websocket pipe tests).
+    Echo,
+    /// Respond to any request with a fixed `200 OK`.
+    HttpOk,
+    /// Respond `200 OK` whose body is the raw request received (so the test can
+    /// inspect the headers the data plane forwarded, e.g. `X-Forwarded-For`).
+    ReflectRequest,
+    /// Respond `200 OK` after a delay.
+    Slow(Duration),
+    /// Nothing listening — connections are refused (customer down).
+    Refuse,
+}
+
+/// A fake customer process on `127.0.0.1`. The data plane forwards to
+/// `127.0.0.1:<port>`, so pass [`Self::port`] as the data-plane port.
+pub struct FakeCustomer {
+    pub addr: SocketAddr,
+    _handle: Option<JoinHandle<()>>,
+}
+
+impl FakeCustomer {
+    pub async fn spawn(mode: CustomerMode) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind customer");
+        let addr = listener.local_addr().expect("customer addr");
+
+        if let CustomerMode::Refuse = mode {
+            // Drop the listener so connections to `addr` are refused.
+            drop(listener);
+            return Self {
+                addr,
+                _handle: None,
+            };
+        }
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    match mode {
+                        CustomerMode::Echo => {
+                            let (mut r, mut w) = sock.split();
+                            let _ = tokio::io::copy(&mut r, &mut w).await;
+                        }
+                        CustomerMode::HttpOk => respond_ok(&mut sock).await,
+                        CustomerMode::ReflectRequest => reflect_request(&mut sock).await,
+                        CustomerMode::Slow(delay) => {
+                            tokio::time::sleep(delay).await;
+                            respond_ok(&mut sock).await;
+                        }
+                        CustomerMode::Refuse => unreachable!(),
+                    }
+                });
+            }
+        });
+
+        Self {
+            addr,
+            _handle: Some(handle),
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.addr.port()
+    }
+}
+
+async fn respond_ok(sock: &mut TcpStream) {
+    let mut buf = [0u8; 8192];
+    // Read (at least) the request head; ignore the contents.
+    let _ = sock.read(&mut buf).await;
+    let response = "HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\nOK";
+    let _ = sock.write_all(response.as_bytes()).await;
+    let _ = sock.flush().await;
+}
+
+async fn reflect_request(sock: &mut TcpStream) {
+    let mut buf = vec![0u8; 8192];
+    let n = sock.read(&mut buf).await.unwrap_or(0);
+    let body = &buf[..n];
+    let header = format!(
+        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    );
+    let _ = sock.write_all(header.as_bytes()).await;
+    let _ = sock.write_all(body).await;
+    let _ = sock.flush().await;
+}
+
+/// A PROXY-protocol v2 header for a TCP/IPv4 connection from `1.2.3.4:80` to
+/// `5.6.7.8:443`, to be written on the raw socket before the TLS `ClientHello`.
+pub fn proxy_v2_header_ipv4() -> Vec<u8> {
+    vec![
+        // 12-byte v2 signature
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
+        0x21, // version 2 | PROXY command
+        0x11, // AF_INET | STREAM
+        0x00, 0x0C, // 12 bytes of address data follow
+        1, 2, 3, 4, // source address 1.2.3.4
+        5, 6, 7, 8, // destination address 5.6.7.8
+        0x00, 0x50, // source port 80
+        0x01, 0xBB, // destination port 443
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Real TLS server under test
+// ---------------------------------------------------------------------------
+
+/// A running data-plane server (real TLS) on loopback. `Drop` aborts the accept
+/// loop.
+pub struct TestServerHandle {
+    pub addr: SocketAddr,
+    pub config: AcceptorConfig,
+    pub metrics: Arc<AcceptMetrics>,
+    handle: JoinHandle<Result<(), crate::server::error::TlsError>>,
+}
+
+impl Drop for TestServerHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl TestServerHandle {
+    /// Spawn `run_with` against a fresh `127.0.0.1:0` TCP listener, terminating
+    /// real TLS and forwarding to `customer_port`.
+    pub async fn spawn(
+        config: AcceptorConfig,
+        customer_port: u16,
+        feature_context: FeatureContext,
+        metrics: Arc<AcceptMetrics>,
+    ) -> Self {
+        seed_enclave_context();
+
+        let listener = TcpServer::bind("127.0.0.1:0").await.expect("bind server");
+        let addr = listener.local_addr().expect("server addr");
+
+        let handshaker = TlsHandshaker::new(test_tls_acceptor());
+        let enclave_context = Arc::new(EnclaveContext::get().expect("context seeded"));
+        let feature_context = Arc::new(feature_context);
+        let e3_client = Arc::new(E3Client::new());
+
+        // Keep the trx-log channel alive + drained.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+        // The production tower stack (no AttestLayer — that is enclave-only).
+        let service = tower::ServiceBuilder::new()
+            .layer(ContextLogLayer::new(
+                enclave_context.clone(),
+                feature_context.clone(),
+                tx.clone(),
+            ))
+            .option_layer(
+                feature_context
+                    .api_key_auth
+                    .then(|| AuthLayer::new(e3_client.clone(), enclave_context.clone())),
+            )
+            .layer(DecryptLayer::new(e3_client.clone()))
+            .service(ForwardService);
+
+        let handle = tokio::spawn(run_with(
+            listener,
+            handshaker,
+            config.clone(),
+            service,
+            customer_port,
+            enclave_context,
+            feature_context,
+            e3_client,
+            tx,
+            metrics.clone(),
+        ));
+
+        Self {
+            addr,
+            config,
+            metrics,
+            handle,
+        }
+    }
+}
+
+/// Build a feature context with auth toggled (other fields defaulted).
+pub fn feature_context_with_auth(api_key_auth: bool) -> FeatureContext {
+    FeatureContext {
+        api_key_auth,
+        ..fake_feature_context()
+    }
+}
+
+#[cfg(test)]
+mod smoke {
+    use super::*;
+    use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn server_starts_and_serves_a_request() {
+        let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+        let metrics = AcceptMetrics::new();
+        let server = TestServerHandle::spawn(
+            AcceptorConfig::serial_compat(),
+            customer.port(),
+            feature_context_with_auth(false),
+            metrics,
+        )
+        .await;
+
+        let response = request_response(server.addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let text = String::from_utf8_lossy(&response);
+        assert!(text.contains("200"), "expected 200 OK, got: {text:?}");
+    }
+}

--- a/crates/data-plane/src/server/e2e_support.rs
+++ b/crates/data-plane/src/server/e2e_support.rs
@@ -122,7 +122,7 @@ pub async fn request_response(addr: SocketAddr, request: &[u8]) -> Vec<u8> {
 // Fake customer process
 // ---------------------------------------------------------------------------
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CustomerMode {
     /// Echo every byte back (for non-HTTP / websocket pipe tests).
     Echo,
@@ -151,7 +151,7 @@ impl FakeCustomer {
             .expect("bind customer");
         let addr = listener.local_addr().expect("customer addr");
 
-        if let CustomerMode::Refuse = mode {
+        if mode == CustomerMode::Refuse {
             // Drop the listener so connections to `addr` are refused.
             drop(listener);
             return Self {

--- a/crates/data-plane/src/server/e2e_tests.rs
+++ b/crates/data-plane/src/server/e2e_tests.rs
@@ -39,7 +39,11 @@ async fn test1_happy_path_request_response() {
         let response = request_response(server.addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
         let text = String::from_utf8_lossy(&response);
         assert!(text.contains("200"), "expected 200, got {text:?}");
-        assert!(text.contains("OK"), "expected body, got {text:?}");
+        let body = text
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .unwrap_or_default();
+        assert_eq!(body, "OK", "expected body, got {text:?}");
     }
 }
 

--- a/crates/data-plane/src/server/e2e_tests.rs
+++ b/crates/data-plane/src/server/e2e_tests.rs
@@ -1,0 +1,396 @@
+use std::time::Duration;
+
+use serial_test::serial;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use crate::server::config::AcceptorConfig;
+use crate::server::e2e_support::{
+    connect_tls, connect_tls_with_prefix, feature_context_with_auth, proxy_v2_header_ipv4,
+    read_until_idle, request_response, CustomerMode, FakeCustomer, TestServerHandle,
+};
+use crate::server::metrics::AcceptMetrics;
+
+/// The acceptor profiles a correctness test should hold under.
+fn configs() -> Vec<AcceptorConfig> {
+    vec![
+        AcceptorConfig::serial_compat(),
+        AcceptorConfig::concurrent_default(),
+    ]
+}
+
+const IDLE: Duration = Duration::from_millis(500);
+
+// Test 1 — happy path: one client, real TLS, GET /, customer replies, the
+// client receives the response.
+#[tokio::test]
+#[serial]
+async fn test1_happy_path_request_response() {
+    for config in configs() {
+        let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+        let server = TestServerHandle::spawn(
+            config,
+            customer.port(),
+            feature_context_with_auth(false),
+            AcceptMetrics::new(),
+        )
+        .await;
+
+        let response = request_response(server.addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let text = String::from_utf8_lossy(&response);
+        assert!(text.contains("200"), "expected 200, got {text:?}");
+        assert!(text.contains("OK"), "expected body, got {text:?}");
+    }
+}
+
+// Test 2 — keep-alive: two requests on the *same* TLS connection are both served
+// (guards the per-connection serve loop).
+#[tokio::test]
+#[serial]
+async fn test2_two_requests_one_connection() {
+    for config in configs() {
+        let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+        let server = TestServerHandle::spawn(
+            config,
+            customer.port(),
+            feature_context_with_auth(false),
+            AcceptMetrics::new(),
+        )
+        .await;
+
+        let mut stream = connect_tls(server.addr).await;
+
+        stream
+            .write_all(b"GET /a HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let r1 = read_until_idle(&mut stream, IDLE).await;
+        assert!(
+            String::from_utf8_lossy(&r1).contains("200"),
+            "first response missing 200: {:?}",
+            String::from_utf8_lossy(&r1)
+        );
+
+        stream
+            .write_all(b"GET /b HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let r2 = read_until_idle(&mut stream, IDLE).await;
+        assert!(
+            String::from_utf8_lossy(&r2).contains("200"),
+            "second response missing 200: {:?}",
+            String::from_utf8_lossy(&r2)
+        );
+    }
+}
+
+// Test 3 — a non-HTTP request is piped raw to the customer when auth is disabled.
+#[tokio::test]
+#[serial]
+async fn test3_non_http_piped_when_auth_disabled() {
+    let customer = FakeCustomer::spawn(CustomerMode::Echo).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::serial_compat(),
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    let mut stream = connect_tls(server.addr).await;
+    let payload: &[u8] = b"\x00\x01\x02NON-HTTP-PAYLOAD\x03\x04";
+    stream.write_all(payload).await.unwrap();
+
+    let echoed = read_until_idle(&mut stream, IDLE).await;
+    assert_eq!(
+        &echoed, payload,
+        "non-http bytes should be piped to the customer and echoed back"
+    );
+}
+
+// Test 3b — with auth enabled, a non-HTTP request is closed (not piped).
+#[tokio::test]
+#[serial]
+async fn test3b_non_http_rejected_when_auth_enabled() {
+    let customer = FakeCustomer::spawn(CustomerMode::Echo).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::serial_compat(),
+        customer.port(),
+        feature_context_with_auth(true),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    let mut stream = connect_tls(server.addr).await;
+    let payload: &[u8] = b"\x00\x01\x02NON-HTTP-PAYLOAD\x03\x04";
+    stream.write_all(payload).await.unwrap();
+
+    let response = read_until_idle(&mut stream, IDLE).await;
+    assert!(
+        response.is_empty(),
+        "auth-enabled non-http connection should be closed without piping, got {response:?}"
+    );
+}
+
+// Test 4 — a websocket upgrade is detected and piped to the customer (auth off).
+#[tokio::test]
+#[serial]
+async fn test4_websocket_piped_when_auth_disabled() {
+    let customer = FakeCustomer::spawn(CustomerMode::Echo).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::serial_compat(),
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    let mut stream = connect_tls(server.addr).await;
+    stream
+        .write_all(
+            b"GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        )
+        .await
+        .unwrap();
+
+    let echoed = read_until_idle(&mut stream, IDLE).await;
+    let text = String::from_utf8_lossy(&echoed);
+    assert!(
+        text.contains("websocket") || text.contains("/ws"),
+        "expected the websocket request to be piped to the customer, got {text:?}"
+    );
+}
+
+// Test 4b — with auth enabled, a websocket upgrade without an api-key is rejected
+// (not piped).
+#[tokio::test]
+#[serial]
+async fn test4b_websocket_rejected_without_api_key() {
+    let customer = FakeCustomer::spawn(CustomerMode::Echo).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::serial_compat(),
+        customer.port(),
+        feature_context_with_auth(true),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    let mut stream = connect_tls(server.addr).await;
+    stream
+        .write_all(b"GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n\r\n")
+        .await
+        .unwrap();
+
+    let response = read_until_idle(&mut stream, IDLE).await;
+    let text = String::from_utf8_lossy(&response);
+    assert!(!response.is_empty(), "expected a rejection response");
+    assert!(
+        !text.contains("/ws"),
+        "unauthorized websocket request must not be piped, got {text:?}"
+    );
+}
+
+// Test 5 — malformed / non-TLS bytes are rejected without taking down the
+// server: a subsequent well-formed client still succeeds.
+#[tokio::test]
+#[serial]
+async fn test5_malformed_tls_does_not_kill_server() {
+    let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::serial_compat(),
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    {
+        let mut tcp = TcpStream::connect(server.addr).await.unwrap();
+        let _ = tcp
+            .write_all(b"this is definitely not a TLS client hello\r\n\r\n")
+            .await;
+        let _ = tcp.shutdown().await;
+    }
+
+    let response = request_response(server.addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+    assert!(
+        String::from_utf8_lossy(&response).contains("200"),
+        "server should survive malformed input and serve the next client"
+    );
+}
+
+// Test 6 — customer process down → clean error response, server survives.
+#[tokio::test]
+#[serial]
+async fn test6_customer_down_clean_error_server_survives() {
+    let customer = FakeCustomer::spawn(CustomerMode::Refuse).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::serial_compat(),
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    let response = request_response(server.addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+    let text = String::from_utf8_lossy(&response);
+    assert!(
+        text.contains("500") || text.contains("message"),
+        "expected a clean error response when the customer is down, got {text:?}"
+    );
+
+    // The server is still accepting + serving connections.
+    let mut stream = connect_tls(server.addr).await;
+    stream
+        .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+        .await
+        .unwrap();
+    let r2 = read_until_idle(&mut stream, IDLE).await;
+    assert!(
+        !r2.is_empty(),
+        "server should still respond after a customer failure"
+    );
+}
+
+// Test 7 — a PROXY v2 header is parsed and the recovered remote addr is forwarded
+// as X-Forwarded-For.
+#[tokio::test]
+#[serial]
+async fn test7_proxy_protocol_recovers_remote_addr() {
+    for config in configs() {
+        let customer = FakeCustomer::spawn(CustomerMode::ReflectRequest).await;
+        let server = TestServerHandle::spawn(
+            config,
+            customer.port(),
+            feature_context_with_auth(false),
+            AcceptMetrics::new(),
+        )
+        .await;
+
+        let header = proxy_v2_header_ipv4();
+        let mut stream = connect_tls_with_prefix(server.addr, Some(&header)).await;
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+
+        let response = read_until_idle(&mut stream, IDLE).await;
+        let text = String::from_utf8_lossy(&response).to_lowercase();
+        assert!(
+            text.contains("x-forwarded-for: 1.2.3.4"),
+            "expected X-Forwarded-For: 1.2.3.4 in the reflected request, got {text:?}"
+        );
+    }
+}
+
+// Test 14 — end-to-end handshake timeout: a real client completes the TCP
+// connect then sends nothing; with a short real `handshake_timeout` the server
+// closes it and keeps serving other clients. (Real time — kept to one test.)
+#[tokio::test]
+#[serial]
+async fn test14_end_to_end_handshake_timeout() {
+    let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+    let config = AcceptorConfig {
+        max_concurrent_connections: 64,
+        max_concurrent_handshakes: 64,
+        handshake_timeout: Some(Duration::from_millis(200)),
+    };
+    let server = TestServerHandle::spawn(
+        config,
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+
+    // Connect but never send a ClientHello.
+    let mut stalled = TcpStream::connect(server.addr).await.unwrap();
+
+    // A well-formed client is still served despite the stalled handshake.
+    let response = request_response(server.addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+    assert!(
+        String::from_utf8_lossy(&response).contains("200"),
+        "other clients should be served while a handshake is stalled"
+    );
+
+    // The stalled connection is closed by the server once the timeout fires.
+    let mut buf = [0u8; 16];
+    let n = tokio::time::timeout(Duration::from_secs(2), stalled.read(&mut buf))
+        .await
+        .expect("stalled connection should be closed by the handshake timeout")
+        .expect("read after close");
+    assert_eq!(n, 0, "server should close the stalled handshake (EOF)");
+}
+
+// Test 22 — N concurrent real clients all succeed under the concurrent profile
+// (smoke test that nothing deadlocks under real load).
+#[tokio::test]
+#[serial]
+async fn test22_many_concurrent_clients_succeed() {
+    let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::concurrent_default(),
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+    let addr = server.addr;
+
+    let mut clients = Vec::new();
+    for _ in 0..50 {
+        clients.push(tokio::spawn(async move {
+            // Two sequential requests on one keep-alive connection.
+            let mut stream = connect_tls(addr).await;
+            for _ in 0..2 {
+                stream
+                    .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+                    .await
+                    .unwrap();
+                let response = read_until_idle(&mut stream, IDLE).await;
+                if !String::from_utf8_lossy(&response).contains("200") {
+                    return false;
+                }
+            }
+            true
+        }));
+    }
+
+    for client in clients {
+        assert!(
+            client.await.unwrap(),
+            "every concurrent client should succeed"
+        );
+    }
+}
+
+// Test 25 — a scaled-down concurrent soak on a multi-thread runtime, to flush
+// out races in the shared service / cert resolver under real parallelism.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn test25_concurrent_clients_multi_thread() {
+    let customer = FakeCustomer::spawn(CustomerMode::HttpOk).await;
+    let server = TestServerHandle::spawn(
+        AcceptorConfig::concurrent_default(),
+        customer.port(),
+        feature_context_with_auth(false),
+        AcceptMetrics::new(),
+    )
+    .await;
+    let addr = server.addr;
+
+    let mut clients = Vec::new();
+    for _ in 0..20 {
+        clients.push(tokio::spawn(async move {
+            let response = request_response(addr, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+            String::from_utf8_lossy(&response).contains("200")
+        }));
+    }
+
+    for client in clients {
+        assert!(
+            client.await.unwrap(),
+            "every concurrent client should succeed under multi-thread"
+        );
+    }
+}

--- a/crates/data-plane/src/server/error.rs
+++ b/crates/data-plane/src/server/error.rs
@@ -41,3 +41,11 @@ pub enum TlsError {
 }
 
 pub type ServerResult<T> = Result<T, TlsError>;
+
+#[derive(Error, Debug)]
+pub enum LogError {
+    #[error("ContextError - Failed to access Enclave context: {0}")]
+    Context(#[from] ContextError),
+    #[error("Failed to build transaction context: {0}")]
+    TrxContextBuild(#[from] shared::logging::TrxContextBuilderError),
+}

--- a/crates/data-plane/src/server/handshake.rs
+++ b/crates/data-plane/src/server/handshake.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use shared::server::proxy_protocol::{try_parse_proxy_protocol, AcceptedConn, ProxiedConnection};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_rustls::server::TlsStream;
+use tokio_rustls::TlsAcceptor;
+
+use crate::server::error::TlsError;
+
+// Maps a raw connection into a high level connection object ready to be served.
+// This abstracts away the PROXY protocol parsing and TLS handshake so both can move off the accept
+// loop and be bound by the same handshake timeout
+#[async_trait]
+pub trait Handshaker<Raw>: Send + Sync {
+    type Output: AsyncRead + AsyncWrite + ProxiedConnection + Send + Unpin + 'static;
+    async fn handshake(&self, raw: Raw) -> Result<Self::Output, TlsError>;
+}
+
+// Production implementation of the Handshaker, handles both PROXY protocol and TLS
+#[derive(Clone)]
+pub struct TlsHandshaker {
+    tls_acceptor: TlsAcceptor,
+}
+
+impl TlsHandshaker {
+    pub fn new(tls_acceptor: TlsAcceptor) -> Self {
+        Self { tls_acceptor }
+    }
+}
+
+#[async_trait]
+impl<Raw> Handshaker<Raw> for TlsHandshaker
+where
+    Raw: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+{
+    type Output = TlsStream<AcceptedConn<Raw>>;
+
+    async fn handshake(&self, raw: Raw) -> Result<Self::Output, TlsError> {
+        let accepted_conn = try_parse_proxy_protocol(raw).await?;
+        let tls_conn = self.tls_acceptor.accept(accepted_conn).await?;
+        Ok(tls_conn)
+    }
+}

--- a/crates/data-plane/src/server/metrics.rs
+++ b/crates/data-plane/src/server/metrics.rs
@@ -1,0 +1,142 @@
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct AcceptMetrics {
+    accepted: AtomicU64,
+    admitted: AtomicU64,
+    shed: AtomicU64,
+    in_flight: AtomicUsize,
+    peak_in_flight: AtomicUsize,
+    in_handshake: AtomicUsize,
+    peak_in_handshake: AtomicUsize,
+    handshake_ok: AtomicU64,
+    handshake_err: AtomicU64,
+    handshake_timed_out: AtomicU64,
+    served: AtomicU64,
+}
+
+impl AcceptMetrics {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn record_accepted(&self) {
+        self.accepted.fetch_add(1, Ordering::SeqCst);
+    }
+    pub fn record_admitted(&self) {
+        self.admitted.fetch_add(1, Ordering::SeqCst);
+    }
+    pub fn record_shed(&self) {
+        self.shed.fetch_add(1, Ordering::SeqCst);
+    }
+    pub fn record_handshake_ok(&self) {
+        self.handshake_ok.fetch_add(1, Ordering::SeqCst);
+    }
+    pub fn record_handshake_err(&self) {
+        self.handshake_err.fetch_add(1, Ordering::SeqCst);
+    }
+    pub fn record_handshake_timed_out(&self) {
+        self.handshake_timed_out.fetch_add(1, Ordering::SeqCst);
+    }
+    pub fn record_served(&self) {
+        self.served.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn accepted(&self) -> u64 {
+        self.accepted.load(Ordering::SeqCst)
+    }
+    pub fn admitted(&self) -> u64 {
+        self.admitted.load(Ordering::SeqCst)
+    }
+    pub fn shed(&self) -> u64 {
+        self.shed.load(Ordering::SeqCst)
+    }
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::SeqCst)
+    }
+    pub fn peak_in_flight(&self) -> usize {
+        self.peak_in_flight.load(Ordering::SeqCst)
+    }
+    pub fn in_handshake(&self) -> usize {
+        self.in_handshake.load(Ordering::SeqCst)
+    }
+    pub fn peak_in_handshake(&self) -> usize {
+        self.peak_in_handshake.load(Ordering::SeqCst)
+    }
+    pub fn handshake_ok(&self) -> u64 {
+        self.handshake_ok.load(Ordering::SeqCst)
+    }
+    pub fn handshake_err(&self) -> u64 {
+        self.handshake_err.load(Ordering::SeqCst)
+    }
+    pub fn handshake_timed_out(&self) -> u64 {
+        self.handshake_timed_out.load(Ordering::SeqCst)
+    }
+    pub fn served(&self) -> u64 {
+        self.served.load(Ordering::SeqCst)
+    }
+
+    pub fn enter_in_flight(self: &Arc<Self>) -> InFlightGuard {
+        let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_in_flight.fetch_max(current, Ordering::SeqCst);
+        InFlightGuard(self.clone())
+    }
+
+    pub fn enter_handshake(self: &Arc<Self>) -> HandshakeGuard {
+        let current = self.in_handshake.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_in_handshake.fetch_max(current, Ordering::SeqCst);
+        HandshakeGuard(self.clone())
+    }
+}
+
+pub struct InFlightGuard(Arc<AcceptMetrics>);
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.0.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+pub struct HandshakeGuard(Arc<AcceptMetrics>);
+
+impl Drop for HandshakeGuard {
+    fn drop(&mut self) {
+        self.0.in_handshake.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn in_flight_guard_tracks_peak_and_releases() {
+        let metrics = AcceptMetrics::new();
+        {
+            let _g1 = metrics.enter_in_flight();
+            assert_eq!(metrics.in_flight(), 1);
+            {
+                let _g2 = metrics.enter_in_flight();
+                assert_eq!(metrics.in_flight(), 2);
+                assert_eq!(metrics.peak_in_flight(), 2);
+            }
+            assert_eq!(metrics.in_flight(), 1);
+            assert_eq!(metrics.peak_in_flight(), 2);
+        }
+        assert_eq!(metrics.in_flight(), 0);
+        assert_eq!(metrics.peak_in_flight(), 2);
+    }
+
+    #[test]
+    fn handshake_guard_tracks_peak_and_releases() {
+        let metrics = AcceptMetrics::new();
+        {
+            let _g = metrics.enter_handshake();
+            assert_eq!(metrics.in_handshake(), 1);
+            assert_eq!(metrics.peak_in_handshake(), 1);
+        }
+        assert_eq!(metrics.in_handshake(), 0);
+        assert_eq!(metrics.peak_in_handshake(), 1);
+    }
+}

--- a/crates/data-plane/src/server/mod.rs
+++ b/crates/data-plane/src/server/mod.rs
@@ -1,10 +1,23 @@
+pub mod config;
+#[cfg(all(test, feature = "tls_termination"))]
+pub mod e2e_support;
+#[cfg(all(test, feature = "tls_termination"))]
+mod e2e_tests;
 pub mod error;
+#[cfg(feature = "tls_termination")]
+pub mod handshake;
 #[cfg(feature = "tls_termination")]
 pub mod http;
 #[cfg(feature = "tls_termination")]
 pub mod layers;
 #[cfg(feature = "tls_termination")]
+pub mod metrics;
+#[cfg(all(test, feature = "tls_termination"))]
+mod policy_tests;
+#[cfg(feature = "tls_termination")]
 #[allow(clippy::module_inception)]
 pub mod server;
+#[cfg(all(test, feature = "tls_termination"))]
+pub mod test_support;
 #[cfg(feature = "tls_termination")]
 pub mod tls;

--- a/crates/data-plane/src/server/policy_tests.rs
+++ b/crates/data-plane/src/server/policy_tests.rs
@@ -1,0 +1,668 @@
+use std::time::Duration;
+
+use crate::server::config::AcceptorConfig;
+use crate::server::metrics::AcceptMetrics;
+use crate::server::test_support::{
+    settle, settle_until, spawn_policy_server, FakeHandshaker, HandshakeBehaviour,
+    ScriptedListener, ScriptedListenerBuilder,
+};
+
+fn config(connections: usize, handshakes: usize, timeout: Option<Duration>) -> AcceptorConfig {
+    AcceptorConfig {
+        max_concurrent_connections: connections,
+        max_concurrent_handshakes: handshakes,
+        handshake_timeout: timeout,
+    }
+}
+
+// ===========================================================================
+// §4.2 Handshake concurrency
+// ===========================================================================
+
+// Test 8 (serial arm) — under serial config a slow handshake blocks every other
+// connection: nothing completes while conn 0 is mid-handshake, and conn 0
+// completes *first* once it finishes.
+#[tokio::test(start_paused = true)]
+async fn test8_slow_handshake_blocks_others_serial() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    let slow = builder.push(HandshakeBehaviour::SucceedAfter(Duration::from_secs(10)));
+    builder.push_many(9, HandshakeBehaviour::Instant);
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker.clone(),
+        AcceptorConfig::serial_compat(),
+        metrics.clone(),
+    );
+
+    // Loop is blocked inline on conn 0's 10s handshake; clock has not advanced.
+    settle().await;
+    assert_eq!(
+        handshaker.completion_order(),
+        Vec::<usize>::new(),
+        "serial: instant conns must be stuck behind the slow handshake"
+    );
+    assert_eq!(
+        metrics.accepted(),
+        1,
+        "serial: only conn 0 pulled off the listener"
+    );
+
+    // Let conn 0 finish; the rest then drain in order.
+    tokio::time::advance(Duration::from_secs(11)).await;
+    assert!(settle_until(|| handshaker.completion_order().len() == 10).await);
+    let order = handshaker.completion_order();
+    assert_eq!(order[0], slow, "serial: the slow conn completes first");
+
+    handle.abort();
+}
+
+// Test 8 (concurrent arm) — the 9 instant conns complete while conn 0 is still
+// handshaking; conn 0 completes last (only after we advance past its deadline).
+#[tokio::test(start_paused = true)]
+async fn test8_slow_handshake_does_not_block_others_concurrent() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    let slow = builder.push(HandshakeBehaviour::SucceedAfter(Duration::from_secs(10)));
+    builder.push_many(9, HandshakeBehaviour::Instant);
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker.clone(),
+        AcceptorConfig::concurrent_default(),
+        metrics.clone(),
+    );
+
+    assert!(
+        settle_until(|| handshaker.completion_order().len() == 9).await,
+        "concurrent: instant conns complete while conn 0 handshakes"
+    );
+    assert!(
+        !handshaker.completion_order().contains(&slow),
+        "concurrent: slow conn must not have completed yet"
+    );
+
+    tokio::time::advance(Duration::from_secs(11)).await;
+    assert!(settle_until(|| handshaker.completion_order().contains(&slow)).await);
+
+    handle.abort();
+}
+
+// Test 9 (serial arm) — a stalled handshake on conn 0 wedges the accept loop:
+// the listener stays at depth 1, no further connections are pulled.
+#[tokio::test(start_paused = true)]
+async fn test9_stalled_handshake_blocks_accept_serial() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push(HandshakeBehaviour::Stall);
+    builder.push_many(5, HandshakeBehaviour::Instant);
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker,
+        AcceptorConfig::serial_compat(),
+        metrics.clone(),
+    );
+
+    settle().await;
+    assert_eq!(
+        metrics.accepted(),
+        1,
+        "serial: loop stuck on conn 0's stalled handshake"
+    );
+
+    // Even after a long time the stall never resolves, so the loop never advances.
+    tokio::time::advance(Duration::from_secs(600)).await;
+    settle().await;
+    assert_eq!(
+        metrics.accepted(),
+        1,
+        "serial: still only conn 0 was accepted"
+    );
+
+    handle.abort();
+}
+
+// Test 9 (concurrent arm) — a stalled handshake does not stop the accept loop:
+// all connections are pulled off the listener and the instant ones complete.
+#[tokio::test(start_paused = true)]
+async fn test9_stalled_handshake_keeps_accepting_concurrent() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push(HandshakeBehaviour::Stall);
+    builder.push_many(5, HandshakeBehaviour::Instant);
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker.clone(),
+        AcceptorConfig::concurrent_default(),
+        metrics.clone(),
+    );
+
+    assert!(
+        settle_until(|| metrics.accepted() == 6).await,
+        "concurrent: accept loop keeps draining past the stalled handshake"
+    );
+    assert!(
+        settle_until(|| handshaker.completion_order().len() == 5).await,
+        "concurrent: the 5 instant conns get through the handshake phase"
+    );
+
+    handle.abort();
+}
+
+// Test 10 — peak concurrent handshakes is bounded by `max_concurrent_handshakes`.
+// Inject 100 slow handshakes against a small handshake cap; the cap binds and is
+// never exceeded (excess is shed).
+#[tokio::test(start_paused = true)]
+async fn test10_peak_handshakes_bounded() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push_many(
+        100,
+        HandshakeBehaviour::SucceedAfter(Duration::from_secs(10)),
+    );
+
+    let cfg = config(1000, 8, None);
+    let handle = spawn_policy_server(builder.build(), handshaker, cfg, metrics.clone());
+
+    // All 100 are pulled off the listener; only 8 can be in handshake at once.
+    assert!(settle_until(|| metrics.accepted() == 100).await);
+    assert!(
+        metrics.peak_in_handshake() <= 8,
+        "peak in-handshake {} exceeded the cap of 8",
+        metrics.peak_in_handshake()
+    );
+    assert_eq!(
+        metrics.peak_in_handshake(),
+        8,
+        "the handshake cap should bind"
+    );
+
+    handle.abort();
+}
+
+// ===========================================================================
+// §4.3 Handshake timeout
+// ===========================================================================
+
+// Test 11 — a stalled handshake is abandoned after `handshake_timeout`, its slot
+// is released, and a connection injected afterwards can proceed.
+#[tokio::test(start_paused = true)]
+async fn test11_stalled_handshake_times_out_and_releases_slot() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let (listener, sender) = ScriptedListener::channel();
+
+    // Single handshake slot so a later conn can only proceed once it's freed.
+    let cfg = config(10, 1, Some(Duration::from_secs(5)));
+    let handle = spawn_policy_server(listener, handshaker.clone(), cfg, metrics.clone());
+
+    sender.send(HandshakeBehaviour::Stall);
+    assert!(settle_until(|| metrics.in_handshake() == 1).await);
+    assert_eq!(metrics.handshake_timed_out(), 0);
+
+    tokio::time::advance(Duration::from_secs(6)).await;
+    assert!(settle_until(|| metrics.handshake_timed_out() == 1).await);
+    assert_eq!(
+        metrics.in_handshake(),
+        0,
+        "handshake slot released after timeout"
+    );
+
+    // A fresh connection can now grab the freed slot and complete.
+    let fresh = sender.send(HandshakeBehaviour::Instant);
+    assert!(settle_until(|| handshaker.completion_order().contains(&fresh)).await);
+
+    handle.abort();
+}
+
+// Test 12 — a handshake completing just under the deadline succeeds; one that
+// would exceed it is timed out. Pins the boundary.
+#[tokio::test(start_paused = true)]
+async fn test12_handshake_timeout_boundary() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let (listener, sender) = ScriptedListener::channel();
+
+    let cfg = config(10, 10, Some(Duration::from_secs(10)));
+    let handle = spawn_policy_server(listener, handshaker.clone(), cfg, metrics.clone());
+
+    // Just under: 9s handshake with a 10s budget succeeds. Let the task arm its
+    // timers (under paused time, `advance` only fires already-registered timers).
+    let under = sender.send(HandshakeBehaviour::SucceedAfter(Duration::from_secs(9)));
+    assert!(settle_until(|| metrics.in_handshake() == 1).await);
+    tokio::time::advance(Duration::from_secs(9)).await;
+    assert!(settle_until(|| handshaker.completion_order().contains(&under)).await);
+    assert_eq!(metrics.handshake_timed_out(), 0);
+
+    // Over: a 20s handshake (started ~now) hits the 10s budget first.
+    let over = sender.send(HandshakeBehaviour::SucceedAfter(Duration::from_secs(20)));
+    assert!(settle_until(|| metrics.in_handshake() == 1).await);
+    tokio::time::advance(Duration::from_secs(11)).await;
+    assert!(settle_until(|| metrics.handshake_timed_out() == 1).await);
+    assert!(
+        !handshaker.completion_order().contains(&over),
+        "over-deadline conn must not complete"
+    );
+
+    handle.abort();
+}
+
+// Test 13 — with the timeout disabled (`None`, the serial default) a stalled
+// handshake is *never* abandoned. Documents today's behaviour and proves `None`
+// is wired through.
+#[tokio::test(start_paused = true)]
+async fn test13_no_timeout_stall_not_abandoned() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let (listener, sender) = ScriptedListener::channel();
+
+    let handle = spawn_policy_server(
+        listener,
+        handshaker,
+        AcceptorConfig::serial_compat(),
+        metrics.clone(),
+    );
+
+    sender.send(HandshakeBehaviour::Stall);
+    assert!(settle_until(|| metrics.in_handshake() == 1).await);
+
+    // No timeout configured: advancing the clock far does not abandon it.
+    tokio::time::advance(Duration::from_secs(3600)).await;
+    settle().await;
+    assert_eq!(
+        metrics.handshake_timed_out(),
+        0,
+        "no timeout => never abandoned"
+    );
+    assert_eq!(
+        metrics.in_handshake(),
+        1,
+        "still stuck in the handshake phase"
+    );
+
+    handle.abort();
+}
+
+// ===========================================================================
+// §4.4 Backpressure & resource-exhaustion protection
+// ===========================================================================
+
+// Test 15 — total in-flight connections are capped at `max_concurrent_connections`.
+// Fire 4×cap connections; peak in-flight never exceeds the cap (excess is shed).
+#[tokio::test(start_paused = true)]
+async fn test15_total_in_flight_capped() {
+    let cap = 10usize;
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push_many(
+        4 * cap,
+        HandshakeBehaviour::SucceedAfter(Duration::from_secs(5)),
+    );
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker,
+        config(cap, cap, None),
+        metrics.clone(),
+    );
+
+    // While the admitted connections sit in their handshake, in-flight is pinned
+    // at the cap and the rest are shed.
+    assert!(settle_until(|| metrics.in_flight() == cap).await);
+    assert!(
+        metrics.peak_in_flight() <= cap,
+        "peak in-flight {} exceeded cap {cap}",
+        metrics.peak_in_flight()
+    );
+    assert_eq!(
+        metrics.peak_in_flight(),
+        cap,
+        "the connection cap should bind"
+    );
+
+    handle.abort();
+}
+
+// Test 16 — in-handshake concurrency is capped by `max_concurrent_handshakes`
+// *independently* of the total-connection cap. Connections injected paced enough
+// to clear an instant handshake then linger in a long serve accumulate in-flight
+// well beyond the (much smaller) handshake cap.
+#[tokio::test(start_paused = true)]
+async fn test16_handshake_cap_independent_of_connection_cap() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let (listener, sender) = ScriptedListener::channel();
+
+    // conn cap 20, handshake cap 2.
+    let handle = spawn_policy_server(listener, handshaker, config(20, 2, None), metrics.clone());
+
+    for _ in 0..10 {
+        sender.send_spec(
+            HandshakeBehaviour::Instant,
+            None,
+            Some(Duration::from_secs(100)),
+        );
+        settle().await;
+    }
+
+    assert!(
+        settle_until(|| metrics.in_flight() == 10).await,
+        "all 10 connections should be in-flight (serving)"
+    );
+    assert!(
+        metrics.in_flight() > 2,
+        "total in-flight is allowed to exceed the handshake cap"
+    );
+    assert!(
+        metrics.peak_in_handshake() <= 2,
+        "handshakes remain bounded by their own cap, independent of the conn cap"
+    );
+
+    handle.abort();
+}
+
+// Test 17 — connection overflow is rejected immediately (no queue): the accept
+// loop keeps draining (never stalls), excess connections are shed, and the
+// accounting balances.
+#[tokio::test(start_paused = true)]
+async fn test17_connection_overflow_is_shed() {
+    let cap = 4usize;
+    let offered = 20usize;
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    // Long serve so admitted conns hold their connection permit; instant handshake.
+    builder.push_many_spec(
+        offered,
+        HandshakeBehaviour::Instant,
+        Some(Duration::from_secs(100)),
+    );
+
+    // Large handshake cap so the *connection* cap is the binding constraint.
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker,
+        config(cap, 1000, None),
+        metrics.clone(),
+    );
+
+    assert!(
+        settle_until(|| metrics.accepted() as usize == offered).await,
+        "accept loop drains every connection without stalling on admission"
+    );
+    assert!(settle_until(|| metrics.in_flight() == cap).await);
+    assert!(metrics.shed() > 0, "overflow must be shed");
+    assert_eq!(
+        metrics.served() + metrics.shed() + metrics.in_flight() as u64,
+        offered as u64,
+        "served + shed + in-flight == offered"
+    );
+
+    handle.abort();
+}
+
+// Test 18 — handshake-slot overflow is shed even when connection slots are free,
+// confirming either limit alone can trigger a reject.
+#[tokio::test(start_paused = true)]
+async fn test18_handshake_slot_overflow_is_shed() {
+    let offered = 20usize;
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push_many(
+        offered,
+        HandshakeBehaviour::SucceedAfter(Duration::from_secs(100)),
+    );
+
+    // Plenty of connection slots, only 2 handshake slots.
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker,
+        config(1000, 2, None),
+        metrics.clone(),
+    );
+
+    assert!(settle_until(|| metrics.accepted() as usize == offered).await);
+    assert!(settle_until(|| metrics.in_handshake() == 2).await);
+    assert!(
+        metrics.shed() > 0,
+        "connections shed on handshake-slot exhaustion despite free connection slots"
+    );
+    assert!(metrics.peak_in_handshake() <= 2);
+
+    handle.abort();
+}
+
+// Test 19 — latency stays flat under overload: with no queue, the time for an
+// admitted connection to complete does not grow with offered load.
+#[tokio::test(start_paused = true)]
+async fn test19_latency_flat_under_overload() {
+    let handshake_d = Duration::from_secs(2);
+    let small = first_completion_latency(8, handshake_d).await;
+    let large = first_completion_latency(10_000, handshake_d).await;
+    assert_eq!(
+        small, large,
+        "admitted-connection latency must be independent of offered load (no queue)"
+    );
+}
+
+/// Virtual time from server start until the first connection completes its
+/// handshake, for a burst of `offered` connections (conn/handshake cap 8).
+async fn first_completion_latency(offered: usize, handshake_d: Duration) -> Duration {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push_many(offered, HandshakeBehaviour::SucceedAfter(handshake_d));
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker.clone(),
+        config(8, 8, None),
+        metrics,
+    );
+    let start = tokio::time::Instant::now();
+    settle().await;
+    tokio::time::advance(handshake_d + Duration::from_millis(1)).await;
+    assert!(settle_until(|| !handshaker.completion_order().is_empty()).await);
+    let elapsed = start.elapsed();
+    handle.abort();
+    elapsed
+}
+
+// Test 20 — a large instantaneous burst does not spawn unbounded tasks: live
+// in-flight stays bounded by the connection cap and the rest are shed.
+#[tokio::test(start_paused = true)]
+async fn test20_burst_does_not_spawn_unbounded_tasks() {
+    let cap = 16usize;
+    let offered = 10_000usize;
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push_many_spec(
+        offered,
+        HandshakeBehaviour::Instant,
+        Some(Duration::from_secs(100)),
+    );
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker,
+        config(cap, cap, None),
+        metrics.clone(),
+    );
+
+    assert!(settle_until(|| metrics.accepted() as usize == offered).await);
+    assert!(
+        metrics.peak_in_flight() <= cap,
+        "live in-flight {} exceeded cap {cap} under burst",
+        metrics.peak_in_flight()
+    );
+    assert_eq!(
+        metrics.shed() as usize,
+        offered - cap,
+        "everything over the cap is shed"
+    );
+
+    handle.abort();
+}
+
+// Test 21 — both permits are released on every exit path (handshake success →
+// serve end, handshake error, handshake timeout); steady-state gauges return to
+// zero and a fresh connection is still admitted afterwards.
+#[tokio::test(start_paused = true)]
+async fn test21_permits_released_on_every_exit_path() {
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let (listener, sender) = ScriptedListener::channel();
+    let handle = spawn_policy_server(
+        listener,
+        handshaker.clone(),
+        config(4, 4, Some(Duration::from_secs(5))),
+        metrics.clone(),
+    );
+
+    let idle = || metrics.in_flight() == 0 && metrics.in_handshake() == 0;
+
+    // (1) handshake success → serve runs to completion (EOF) → both released.
+    // This path also covers a "serve error": the serve task ending releases the
+    // connection permit identically.
+    sender.send(HandshakeBehaviour::Instant);
+    assert!(settle_until(|| metrics.served() == 1).await);
+    assert!(settle_until(idle).await, "released after success");
+
+    // (2) handshake error → both released without ever serving.
+    sender.send(HandshakeBehaviour::Fail);
+    assert!(settle_until(|| metrics.handshake_err() == 1).await);
+    assert!(settle_until(idle).await, "released after handshake error");
+
+    // (3) handshake timeout → both released when the deadline fires.
+    sender.send(HandshakeBehaviour::Stall);
+    assert!(settle_until(|| metrics.in_handshake() == 1).await);
+    tokio::time::advance(Duration::from_secs(6)).await;
+    assert!(settle_until(|| metrics.handshake_timed_out() == 1).await);
+    assert!(settle_until(idle).await, "released after handshake timeout");
+
+    // Capacity is fully restored: a fresh connection is still admitted + served.
+    let fresh = sender.send(HandshakeBehaviour::Instant);
+    assert!(settle_until(|| handshaker.completion_order().contains(&fresh)).await);
+
+    handle.abort();
+}
+
+// ===========================================================================
+// §4.5 Throughput / soak
+// ===========================================================================
+
+// Test 23 — under slow handshakes the concurrent profile drains a wave of K
+// handshakes in a single `d`, whereas the serial profile completes only one per
+// `d`. Uses the virtual clock so the comparison is deterministic.
+#[tokio::test(start_paused = true)]
+async fn test23_concurrent_faster_than_serial_under_slow_handshakes() {
+    let d = Duration::from_secs(10);
+    let k = 8usize;
+
+    // Concurrent: all K complete in one handshake wave.
+    {
+        let metrics = AcceptMetrics::new();
+        let handshaker = FakeHandshaker::new();
+        let mut builder = ScriptedListenerBuilder::new();
+        builder.push_many(k, HandshakeBehaviour::SucceedAfter(d));
+        let handle = spawn_policy_server(
+            builder.build(),
+            handshaker.clone(),
+            config(64, 64, None),
+            metrics,
+        );
+        settle().await;
+        tokio::time::advance(d + Duration::from_secs(1)).await;
+        assert!(
+            settle_until(|| handshaker.completion_order().len() == k).await,
+            "concurrent: all {k} complete in a single handshake wave"
+        );
+        handle.abort();
+    }
+
+    // Serial: only one completes per wave of `d`.
+    {
+        let metrics = AcceptMetrics::new();
+        let handshaker = FakeHandshaker::new();
+        let mut builder = ScriptedListenerBuilder::new();
+        builder.push_many(k, HandshakeBehaviour::SucceedAfter(d));
+        let handle = spawn_policy_server(
+            builder.build(),
+            handshaker.clone(),
+            AcceptorConfig::serial_compat(),
+            metrics,
+        );
+        settle().await;
+        tokio::time::advance(d + Duration::from_secs(1)).await;
+        assert!(settle_until(|| !handshaker.completion_order().is_empty()).await);
+        assert_eq!(
+            handshaker.completion_order().len(),
+            1,
+            "serial: only one completion per handshake wave"
+        );
+        handle.abort();
+    }
+}
+
+// ===========================================================================
+// §4.6 Thread-safety (multi-thread runtime)
+// ===========================================================================
+
+// Test 24 — under a multi-thread runtime (real parallelism, real time) the two
+// semaphores still hold their caps exactly and the shed/served accounting is
+// exact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test24_concurrent_admission_under_parallelism() {
+    let offered = 200usize;
+    let metrics = AcceptMetrics::new();
+    let handshaker = FakeHandshaker::new();
+    let mut builder = ScriptedListenerBuilder::new();
+    builder.push_many(
+        offered,
+        HandshakeBehaviour::SucceedAfter(Duration::from_millis(5)),
+    );
+
+    let handle = spawn_policy_server(
+        builder.build(),
+        handshaker,
+        config(32, 8, None),
+        metrics.clone(),
+    );
+
+    assert!(
+        crate::server::test_support::wait_until(
+            || (metrics.served() + metrics.shed()) as usize == offered,
+            Duration::from_secs(10),
+        )
+        .await,
+        "all offered connections accounted for"
+    );
+
+    assert!(
+        metrics.peak_in_handshake() <= 8,
+        "handshake cap held under real parallelism"
+    );
+    assert!(
+        metrics.peak_in_flight() <= 32,
+        "connection cap held under real parallelism"
+    );
+    assert_eq!(metrics.accepted() as usize, offered);
+    assert_eq!(
+        (metrics.served() + metrics.shed()) as usize,
+        offered,
+        "exact served/shed accounting"
+    );
+
+    handle.abort();
+}

--- a/crates/data-plane/src/server/policy_tests.rs
+++ b/crates/data-plane/src/server/policy_tests.rs
@@ -410,10 +410,9 @@ async fn test17_connection_overflow_is_shed() {
     handle.abort();
 }
 
-// Test 18 — handshake-slot overflow is shed even when connection slots are free,
-// confirming either limit alone can trigger a reject.
+// Test 18 — handshake-slot overflow waits for another connection to become free and doesn't shed
 #[tokio::test(start_paused = true)]
-async fn test18_handshake_slot_overflow_is_shed() {
+async fn test18_handshake_slot_overflow_awaits_tasks() {
     let offered = 20usize;
     let metrics = AcceptMetrics::new();
     let handshaker = FakeHandshaker::new();
@@ -434,9 +433,10 @@ async fn test18_handshake_slot_overflow_is_shed() {
     assert!(settle_until(|| metrics.accepted() as usize == offered).await);
     assert!(settle_until(|| metrics.in_handshake() == 2).await);
     assert!(
-        metrics.shed() > 0,
-        "connections shed on handshake-slot exhaustion despite free connection slots"
+        metrics.shed() == 0,
+        "avoid shedding on handshake-slot exhaustion"
     );
+    assert!(metrics.peak_in_flight() == offered);
     assert!(metrics.peak_in_handshake() <= 2);
 
     handle.abort();

--- a/crates/data-plane/src/server/server.rs
+++ b/crates/data-plane/src/server/server.rs
@@ -1,7 +1,10 @@
+use super::config::AcceptorConfig;
 use super::error::TlsError;
+use super::handshake::{Handshaker, TlsHandshaker};
 use super::http::parse::{try_parse_http_request_from_stream, Incoming};
 use super::http::{request_to_bytes, response_to_bytes};
-use super::tls::TlsServerBuilder;
+use super::metrics::AcceptMetrics;
+use super::tls::build_attestable_server_config;
 
 use crate::e3client::{E3Api, E3Client};
 use crate::env::{EnvironmentLoader, NeedCert};
@@ -18,7 +21,8 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tokio_rustls::server::TlsStream;
+use tokio::sync::Semaphore;
+use tokio_rustls::TlsAcceptor;
 use tower::Service;
 
 #[cfg(feature = "enclave")]
@@ -38,12 +42,14 @@ pub async fn run<L: Listener + Send + Sync>(
 ) -> Result<(), TlsError>
 where
     TlsError: From<<L as Listener>::Error>,
-    <L as Listener>::Connection: ProxiedConnection + 'static,
+    <L as Listener>::Connection: 'static,
 {
-    let mut server = TlsServerBuilder::new()
-        .with_server(tcp_server)
-        .with_attestable_cert(env_loader)
-        .await?;
+    let tls_acceptor =
+        TlsAcceptor::from(Arc::new(build_attestable_server_config(env_loader).await?));
+    let handshaker = TlsHandshaker::new(tls_acceptor);
+
+    let acceptor_config = context.acceptor.clone();
+
     let e3_client = Arc::new(E3Client::new());
 
     let (tx, rx): (
@@ -87,71 +93,170 @@ where
         )
         .layer(DecryptLayer::new(e3_client.clone()))
         .service(ForwardService);
+
+    run_with(
+        tcp_server,
+        handshaker,
+        acceptor_config,
+        service,
+        port,
+        enclave_context,
+        feature_context,
+        e3_client,
+        tx,
+        AcceptMetrics::new(),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with<L, H, Svc>(
+    mut listener: L,
+    handshaker: H,
+    config: AcceptorConfig,
+    service: Svc,
+    port: u16,
+    enclave_context: Arc<EnclaveContext>,
+    feature_context: Arc<FeatureContext>,
+    e3_client: Arc<E3Client>,
+    tx: UnboundedSender<LogHandlerMessage>,
+    metrics: Arc<AcceptMetrics>,
+) -> Result<(), TlsError>
+where
+    L: Listener + Send + Sync,
+    TlsError: From<<L as Listener>::Error>,
+    <L as Listener>::Connection: 'static,
+    H: Handshaker<<L as Listener>::Connection> + 'static,
+    Svc: Service<Request<Body>, Response = hyper::Response<Body>> + Clone + Send + 'static,
+    Svc::Error: std::fmt::Debug,
+    Svc::Future: Send,
+{
+    log::info!("Accept loop starting with acceptor policy: {config:?}");
+    let handshaker = Arc::new(handshaker);
+
+    let conn_sem = Arc::new(Semaphore::new(config.max_concurrent_connections));
+    let handshake_sem = Arc::new(Semaphore::new(config.max_concurrent_handshakes));
+    let handshake_timeout = config.handshake_timeout;
+    let serial = config.is_serial();
+
     loop {
-        let mut stream = match server.accept().await {
-            Ok(stream) => stream,
-            Err(tls_err) => {
-                log::error!(
-                    "An error occurred while accepting the incoming connection — {tls_err}"
-                );
+        let raw_conn = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                log::error!("An error occurred while accepting the incoming connection — {e}");
                 continue;
             }
         };
+        metrics.record_accepted();
 
-        let remote_ip = stream.get_remote_addr().clone();
-        let tx_for_connection = tx.clone();
-        let mut data_plane_service = service.clone();
-        let enclave_context_clone = enclave_context.clone();
-        let feature_context_clone = feature_context.clone();
-        let e3_client_clone = e3_client.clone();
-        tokio::spawn(async move {
-            loop {
-                match try_parse_http_request_from_stream(&mut stream, port).await {
-                    Ok(Incoming::HttpRequest(request)) if parse::is_websocket_request(&request) => {
-                        return handle_websocket_request(
-                            &mut stream,
-                            request,
-                            &tx_for_connection,
-                            remote_ip,
-                            enclave_context_clone.clone(),
-                            feature_context_clone.clone(),
-                            e3_client_clone.clone(),
-                            port,
-                        )
-                        .await;
-                    }
-                    Ok(Incoming::HttpRequest(request)) => {
-                        let response = data_plane_service.call(request).await.unwrap_or_else(|e| {
-                            log::error!("Failed to handle incoming request in data plane - {e:?}");
-                            build_internal_error_response(None)
-                        });
-                        let response_bytes = response_to_bytes(response).await;
-                        let _ = stream.write_all(&response_bytes).await;
-                        continue;
-                    }
-                    Ok(Incoming::NonHttpRequest(_)) if feature_context_clone.api_key_auth => {
-                        log::info!(
-                            "Non http request received with auth enabled, closing connection"
-                        );
-                        log_non_http_trx(&tx_for_connection, false, remote_ip, None);
-                        shutdown_conn(&mut stream).await;
-                        return;
-                    }
-                    Ok(Incoming::NonHttpRequest(bytes)) => {
-                        log::info!(
-                            "Non http request received with auth enabled, closing connection"
-                        );
-                        log_non_http_trx(&tx_for_connection, true, remote_ip, None);
-                        let _ = pipe_to_customer_process(&mut stream, &bytes, port).await;
-                        return;
+        if serial {
+            metrics.record_admitted();
+            let conn = {
+                let _handshake_guard = metrics.enter_handshake();
+                match handshaker.handshake(raw_conn).await {
+                    Ok(conn) => {
+                        metrics.record_handshake_ok();
+                        conn
                     }
                     Err(e) => {
-                        log::error!("Connection read error - {e:?}");
-                        shutdown_conn(&mut stream).await;
-                        return;
+                        metrics.record_handshake_err();
+                        log::error!("An error occurred during the connection handshake — {e}");
+                        continue;
                     }
-                };
+                }
+            };
+
+            let remote_ip = conn.get_remote_addr();
+            let in_flight_guard = metrics.enter_in_flight();
+            let task_metrics = metrics.clone();
+            let serve = serve_connection(
+                conn,
+                service.clone(),
+                port,
+                remote_ip,
+                tx.clone(),
+                enclave_context.clone(),
+                feature_context.clone(),
+                e3_client.clone(),
+            );
+            tokio::spawn(async move {
+                let _in_flight_guard = in_flight_guard;
+                serve.await;
+                task_metrics.record_served();
+            });
+            continue;
+        }
+
+        let conn_permit = match conn_sem.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                metrics.record_shed();
+                continue;
             }
+        };
+        let handshake_permit = match handshake_sem.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                metrics.record_shed();
+                continue;
+            }
+        };
+        metrics.record_admitted();
+
+        let in_flight_guard = metrics.enter_in_flight();
+        let task_handshaker = handshaker.clone();
+        let task_service = service.clone();
+        let task_tx = tx.clone();
+        let task_enclave_context = enclave_context.clone();
+        let task_feature_context = feature_context.clone();
+        let task_e3_client = e3_client.clone();
+        let task_metrics = metrics.clone();
+
+        tokio::spawn(async move {
+            let _conn_permit = conn_permit;
+            let _in_flight_guard = in_flight_guard;
+
+            let handshake_result = {
+                let _handshake_permit = handshake_permit;
+                let _handshake_guard = task_metrics.enter_handshake();
+                match handshake_timeout {
+                    Some(timeout) => {
+                        tokio::time::timeout(timeout, task_handshaker.handshake(raw_conn)).await
+                    }
+                    None => Ok(task_handshaker.handshake(raw_conn).await),
+                }
+            };
+
+            let conn = match handshake_result {
+                Ok(Ok(conn)) => {
+                    task_metrics.record_handshake_ok();
+                    conn
+                }
+                Ok(Err(e)) => {
+                    task_metrics.record_handshake_err();
+                    log::error!("An error occurred during the connection handshake - {e}");
+                    return;
+                }
+                Err(_elapsed) => {
+                    task_metrics.record_handshake_timed_out();
+                    log::warn!("Connection handshake exceeded the handshake timeout");
+                    return;
+                }
+            };
+
+            let remote_ip = conn.get_remote_addr();
+            serve_connection(
+                conn,
+                task_service,
+                port,
+                remote_ip,
+                task_tx,
+                task_enclave_context,
+                task_feature_context,
+                task_e3_client,
+            )
+            .await;
+            task_metrics.record_served();
         });
     }
     #[allow(unreachable_code)]
@@ -159,8 +264,69 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
+pub(crate) async fn serve_connection<S, T>(
+    mut stream: S,
+    mut data_plane_service: T,
+    port: u16,
+    remote_ip: Option<String>,
+    tx_for_connection: UnboundedSender<LogHandlerMessage>,
+    enclave_context: Arc<EnclaveContext>,
+    feature_context: Arc<FeatureContext>,
+    e3_client: Arc<E3Client>,
+) where
+    S: AsyncRead + AsyncWrite + ProxiedConnection + Unpin + Send,
+    T: Service<Request<Body>, Response = hyper::Response<Body>>,
+    T::Error: std::fmt::Debug,
+    T::Future: Send,
+{
+    loop {
+        match try_parse_http_request_from_stream(&mut stream, port).await {
+            Ok(Incoming::HttpRequest(request)) if parse::is_websocket_request(&request) => {
+                return handle_websocket_request(
+                    &mut stream,
+                    request,
+                    &tx_for_connection,
+                    remote_ip,
+                    enclave_context.clone(),
+                    feature_context.clone(),
+                    e3_client.clone(),
+                    port,
+                )
+                .await;
+            }
+            Ok(Incoming::HttpRequest(request)) => {
+                let response = data_plane_service.call(request).await.unwrap_or_else(|e| {
+                    log::error!("Failed to handle incoming request in data plane - {e:?}");
+                    build_internal_error_response(None)
+                });
+                let response_bytes = response_to_bytes(response).await;
+                let _ = stream.write_all(&response_bytes).await;
+                continue;
+            }
+            Ok(Incoming::NonHttpRequest(_)) if feature_context.api_key_auth => {
+                log::info!("Non http request received with auth enabled, closing connection");
+                log_non_http_trx(&tx_for_connection, false, remote_ip, None);
+                shutdown_conn(&mut stream).await;
+                return;
+            }
+            Ok(Incoming::NonHttpRequest(bytes)) => {
+                log::info!("Non http request received with auth enabled, closing connection");
+                log_non_http_trx(&tx_for_connection, true, remote_ip, None);
+                let _ = pipe_to_customer_process(&mut stream, &bytes, port).await;
+                return;
+            }
+            Err(e) => {
+                log::error!("Connection read error - {e:?}");
+                shutdown_conn(&mut stream).await;
+                return;
+            }
+        };
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn handle_websocket_request<S: AsyncRead + AsyncWrite + Unpin>(
-    stream: &mut TlsStream<S>,
+    stream: &mut S,
     request: Request<Body>,
     tx_for_connection: &UnboundedSender<LogHandlerMessage>,
     remote_ip: Option<String>,
@@ -210,22 +376,19 @@ async fn authenticate_websocket_request<T: E3Api + Send + Sync + 'static>(
     Ok(())
 }
 
-async fn shutdown_conn<L>(stream: &mut TlsStream<L>)
-where
-    TlsStream<L>: AsyncWriteExt + Unpin,
-{
+async fn shutdown_conn<S: AsyncWrite + Unpin>(stream: &mut S) {
     if let Err(e) = stream.shutdown().await {
         log::error!("Failed to shutdown data plane connection — {e:?}");
     }
 }
 
-async fn pipe_to_customer_process<L>(
-    stream: &mut TlsStream<L>,
+async fn pipe_to_customer_process<S>(
+    stream: &mut S,
     buffer: &[u8],
     port: u16,
 ) -> Result<(), tokio::io::Error>
 where
-    TlsStream<L>: AsyncRead + Unpin + AsyncWrite,
+    S: AsyncRead + Unpin + AsyncWrite,
 {
     let mut customer_stream = TcpStream::connect(("127.0.0.1", port)).await?;
     customer_stream.write_all(buffer).await?;
@@ -251,10 +414,12 @@ fn log_non_http_trx(
         ),
     };
     context_builder.add_httparse_to_trx(authorized, None, remote_ip);
-    let trx_context = context_builder.build().unwrap();
-    tx_sender
-        .send(LogHandlerMessage::new_log_message(trx_context))
-        .unwrap()
+    match context_builder.build() {
+        Ok(trx_context) => {
+            let _ = tx_sender.send(LogHandlerMessage::new_log_message(trx_context));
+        }
+        Err(e) => log::debug!("Skipping trx log for non-http transaction. {e}"),
+    }
 }
 
 #[cfg(test)]
@@ -289,6 +454,7 @@ mod test {
                     ips: std::default::Default::default(),
                 },
             },
+            acceptor: AcceptorConfig::serial_compat(),
         }
     }
 

--- a/crates/data-plane/src/server/server.rs
+++ b/crates/data-plane/src/server/server.rs
@@ -1,5 +1,5 @@
 use super::config::AcceptorConfig;
-use super::error::TlsError;
+use super::error::{LogError, TlsError};
 use super::handshake::{Handshaker, TlsHandshaker};
 use super::http::parse::{try_parse_http_request_from_stream, Incoming};
 use super::http::{request_to_bytes, response_to_bytes};
@@ -305,13 +305,17 @@ pub(crate) async fn serve_connection<S, T>(
             }
             Ok(Incoming::NonHttpRequest(_)) if feature_context.api_key_auth => {
                 log::info!("Non http request received with auth enabled, closing connection");
-                log_non_http_trx(&tx_for_connection, false, remote_ip, None);
+                if let Err(e) = log_non_http_trx(&tx_for_connection, false, remote_ip, None) {
+                    log::debug!("Skipping trx log for non-http transaction. {e}");
+                }
                 shutdown_conn(&mut stream).await;
                 return;
             }
             Ok(Incoming::NonHttpRequest(bytes)) => {
                 log::info!("Non http request received with auth enabled, closing connection");
-                log_non_http_trx(&tx_for_connection, true, remote_ip, None);
+                if let Err(e) = log_non_http_trx(&tx_for_connection, true, remote_ip, None) {
+                    log::debug!("Skipping trx log for non-http transaction. {e}");
+                }
                 let _ = pipe_to_customer_process(&mut stream, &bytes, port).await;
                 return;
             }
@@ -346,12 +350,17 @@ async fn handle_websocket_request<S: AsyncRead + AsyncWrite + Unpin>(
         authenticate_websocket_request(&request, enclave_context, e3_client, &feature_context).await
     {
         let response_bytes = response_to_bytes(e.into()).await;
-        log_non_http_trx(tx_for_connection, false, remote_ip, Some(context_builder));
+        if let Err(e) = log_non_http_trx(tx_for_connection, false, remote_ip, Some(context_builder))
+        {
+            log::debug!("Skipping trx log for non-http transaction. {e}");
+        }
         let _ = stream.write_all(&response_bytes).await;
         return;
     }
 
-    log_non_http_trx(tx_for_connection, true, remote_ip, Some(context_builder));
+    if let Err(e) = log_non_http_trx(tx_for_connection, true, remote_ip, Some(context_builder)) {
+        log::debug!("Skipping trx log for non-http transaction. {e}");
+    }
     let serialized_request = request_to_bytes(request).await;
     let _ = pipe_to_customer_process(stream, &serialized_request, port).await;
 }
@@ -401,25 +410,24 @@ fn log_non_http_trx(
     authorized: bool,
     remote_ip: Option<String>,
     context_builder: Option<TrxContextBuilder>,
-) {
-    let enclave_context = EnclaveContext::get().unwrap();
+) -> Result<(), LogError> {
     let mut context_builder = match context_builder {
         Some(context_builder) => context_builder,
-        _ => TrxContextBuilder::init_trx_context_with_enclave_details(
-            &enclave_context.uuid,
-            &enclave_context.name,
-            &enclave_context.app_uuid,
-            &enclave_context.team_uuid,
-            RequestType::TCP,
-        ),
+        _ => {
+            let enclave_context = EnclaveContext::get()?;
+            TrxContextBuilder::init_trx_context_with_enclave_details(
+                &enclave_context.uuid,
+                &enclave_context.name,
+                &enclave_context.app_uuid,
+                &enclave_context.team_uuid,
+                RequestType::TCP,
+            )
+        }
     };
     context_builder.add_httparse_to_trx(authorized, None, remote_ip);
-    match context_builder.build() {
-        Ok(trx_context) => {
-            let _ = tx_sender.send(LogHandlerMessage::new_log_message(trx_context));
-        }
-        Err(e) => log::debug!("Skipping trx log for non-http transaction. {e}"),
-    }
+    let trx_context = context_builder.build()?;
+    let _ = tx_sender.send(LogHandlerMessage::new_log_message(trx_context));
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/data-plane/src/server/server.rs
+++ b/crates/data-plane/src/server/server.rs
@@ -194,16 +194,10 @@ where
                 continue;
             }
         };
-        let handshake_permit = match handshake_sem.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                metrics.record_shed();
-                continue;
-            }
-        };
         metrics.record_admitted();
 
         let in_flight_guard = metrics.enter_in_flight();
+        let task_handshake_sem = handshake_sem.clone();
         let task_handshaker = handshaker.clone();
         let task_service = service.clone();
         let task_tx = tx.clone();
@@ -215,9 +209,15 @@ where
         tokio::spawn(async move {
             let _conn_permit = conn_permit;
             let _in_flight_guard = in_flight_guard;
+            let handshake_permit = match task_handshake_sem.acquire().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    task_metrics.record_shed();
+                    return;
+                }
+            };
 
             let handshake_result = {
-                let _handshake_permit = handshake_permit;
                 let _handshake_guard = task_metrics.enter_handshake();
                 match handshake_timeout {
                     Some(timeout) => {
@@ -243,6 +243,8 @@ where
                     return;
                 }
             };
+
+            drop(handshake_permit);
 
             let remote_ip = conn.get_remote_addr();
             serve_connection(

--- a/crates/data-plane/src/server/test_support.rs
+++ b/crates/data-plane/src/server/test_support.rs
@@ -1,0 +1,595 @@
+#![allow(dead_code)]
+
+use std::convert::Infallible;
+use std::future;
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hyper::{Body, Request, Response};
+use shared::server::proxy_protocol::ProxiedConnection;
+use shared::server::Listener;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::task::JoinHandle;
+use tower::Service;
+
+use crate::e3client::E3Client;
+use crate::server::config::AcceptorConfig;
+use crate::server::error::TlsError;
+use crate::server::handshake::Handshaker;
+use crate::server::metrics::AcceptMetrics;
+use crate::server::server::run_with;
+use crate::utils::trx_handler::LogHandlerMessage;
+use crate::{EnclaveContext, FeatureContext};
+
+#[cfg(feature = "network_egress")]
+use shared::server::egress::{EgressConfig, EgressDestinations};
+
+// ---------------------------------------------------------------------------
+// Single-knob harness config (§3.1). Layer A drives mostly off `acceptor`; the
+// customer / client / runtime knobs are consumed by the Layer-B harness.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub enum CustomerBehaviour {
+    Echo,
+    HttpOk,
+    Slow(Duration),
+    Refuse,
+}
+
+#[derive(Clone, Debug)]
+pub struct ClientPlan {
+    pub count: usize,
+    pub concurrency: usize,
+    /// Per-client delay before sending the first byte (models a slow client).
+    pub stall_before_hello: Option<Duration>,
+}
+
+impl Default for ClientPlan {
+    fn default() -> Self {
+        Self {
+            count: 1,
+            concurrency: 1,
+            stall_before_hello: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum RuntimeFlavour {
+    CurrentThread,
+    MultiThread(usize),
+}
+
+pub struct HarnessConfig {
+    pub acceptor: AcceptorConfig,
+    pub customer: CustomerBehaviour,
+    pub client_plan: ClientPlan,
+    pub runtime: RuntimeFlavour,
+}
+
+impl Default for HarnessConfig {
+    fn default() -> Self {
+        Self {
+            acceptor: AcceptorConfig::serial_compat(),
+            customer: CustomerBehaviour::HttpOk,
+            client_plan: ClientPlan::default(),
+            runtime: RuntimeFlavour::CurrentThread,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake connections
+// ---------------------------------------------------------------------------
+
+/// What a fake handshake should do for a given connection.
+#[derive(Clone, Debug)]
+pub enum HandshakeBehaviour {
+    /// Complete immediately (success).
+    Instant,
+    /// Complete successfully after sleeping for `Duration` (works with the
+    /// paused clock + `tokio::time::advance`).
+    SucceedAfter(Duration),
+    /// Fail immediately.
+    Fail,
+    /// Never complete — models a stalled `ClientHello`.
+    Stall,
+}
+
+/// The *raw* connection handed to the (fake) handshaker. Carries the per-conn
+/// id + behaviour; its byte stream is inert (the [`FakeHandshaker`] ignores it).
+pub struct ScriptedConn {
+    pub id: usize,
+    pub behaviour: HandshakeBehaviour,
+    pub remote_addr: Option<String>,
+    /// How long the *serve* phase should occupy the connection before EOF.
+    /// `None` => serve returns immediately (EOF). Used to make connections
+    /// linger in-flight (holding a connection permit) after the handshake, so
+    /// tests can show in-flight exceeding the handshake cap.
+    pub serve_delay: Option<Duration>,
+}
+
+impl AsyncRead for ScriptedConn {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        // Immediate EOF — the raw stream is never read in the policy layer.
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for ScriptedConn {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// The connection produced by a successful fake handshake — what the serve loop
+/// reads/writes. Reads (optionally) wait out a serve delay, serve an optional
+/// preloaded buffer, then EOF; writes are discarded; the remote addr is
+/// configurable (for `ProxiedConnection`).
+pub struct FakeServedConn {
+    read_data: Vec<u8>,
+    read_pos: usize,
+    remote_addr: Option<String>,
+    /// Pending serve-delay timer; the first read pends until it fires.
+    serve_delay: Option<Pin<Box<tokio::time::Sleep>>>,
+}
+
+impl FakeServedConn {
+    pub fn eof(remote_addr: Option<String>) -> Self {
+        Self::eof_after(remote_addr, None)
+    }
+
+    /// EOF after `serve_delay` (modelling a serve phase that holds the
+    /// connection in-flight). Must be called within a tokio runtime when
+    /// `serve_delay` is `Some` (it arms a timer).
+    pub fn eof_after(remote_addr: Option<String>, serve_delay: Option<Duration>) -> Self {
+        Self {
+            read_data: Vec::new(),
+            read_pos: 0,
+            remote_addr,
+            serve_delay: serve_delay.map(|d| Box::pin(tokio::time::sleep(d))),
+        }
+    }
+
+    pub fn with_request(bytes: Vec<u8>, remote_addr: Option<String>) -> Self {
+        Self {
+            read_data: bytes,
+            read_pos: 0,
+            remote_addr,
+            serve_delay: None,
+        }
+    }
+}
+
+impl AsyncRead for FakeServedConn {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if let Some(sleep) = this.serve_delay.as_mut() {
+            match std::future::Future::poll(sleep.as_mut(), cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(()) => this.serve_delay = None,
+            }
+        }
+        if this.read_pos < this.read_data.len() {
+            let remaining = &this.read_data[this.read_pos..];
+            let n = remaining.len().min(buf.remaining());
+            buf.put_slice(&remaining[..n]);
+            this.read_pos += n;
+        }
+        // Nothing left => Ready with no bytes put == EOF.
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for FakeServedConn {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl ProxiedConnection for FakeServedConn {
+    fn get_remote_addr(&self) -> Option<String> {
+        self.remote_addr.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scripted listener
+// ---------------------------------------------------------------------------
+
+/// In-memory [`Listener`] backed by a channel of pre-built connections. Once
+/// the queue drains it *idles* (an empty channel makes `accept()` pend) rather
+/// than erroring, mimicking a real listener waiting for the next connection.
+pub struct ScriptedListener {
+    rx: tokio::sync::mpsc::UnboundedReceiver<ScriptedConn>,
+}
+
+#[async_trait]
+impl Listener for ScriptedListener {
+    type Connection = ScriptedConn;
+    type Error = TlsError;
+
+    async fn accept(&mut self) -> Result<Self::Connection, Self::Error> {
+        match self.rx.recv().await {
+            Some(conn) => Ok(conn),
+            // No more scripted connections — idle forever like a quiet listener.
+            None => future::pending().await,
+        }
+    }
+}
+
+impl ScriptedListener {
+    /// A listener fed dynamically through a [`ScriptedSender`]. While the sender
+    /// is alive an empty queue makes `accept()` pend (a quiet listener); drop the
+    /// sender to make it idle permanently. Use this to inject a connection *after*
+    /// advancing the clock (e.g. to prove a freed handshake slot lets a later conn
+    /// through).
+    pub fn channel() -> (Self, ScriptedSender) {
+        let (tx, rx) = unbounded_channel();
+        (
+            Self { rx },
+            ScriptedSender {
+                tx,
+                next_id: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            },
+        )
+    }
+}
+
+/// Handle for injecting connections into a channel-backed [`ScriptedListener`].
+#[derive(Clone)]
+pub struct ScriptedSender {
+    tx: UnboundedSender<ScriptedConn>,
+    next_id: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl ScriptedSender {
+    /// Inject a connection; returns its assigned id.
+    pub fn send(&self, behaviour: HandshakeBehaviour) -> usize {
+        self.send_with_addr(behaviour, None)
+    }
+
+    pub fn send_with_addr(
+        &self,
+        behaviour: HandshakeBehaviour,
+        remote_addr: Option<String>,
+    ) -> usize {
+        self.send_spec(behaviour, remote_addr, None)
+    }
+
+    /// Inject a connection with full control over its remote addr and serve
+    /// delay.
+    pub fn send_spec(
+        &self,
+        behaviour: HandshakeBehaviour,
+        remote_addr: Option<String>,
+        serve_delay: Option<Duration>,
+    ) -> usize {
+        let id = self
+            .next_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let _ = self.tx.send(ScriptedConn {
+            id,
+            behaviour,
+            remote_addr,
+            serve_delay,
+        });
+        id
+    }
+}
+
+/// Builder that assigns sequential ids and pre-loads a [`ScriptedListener`].
+#[derive(Default)]
+pub struct ScriptedListenerBuilder {
+    conns: Vec<ScriptedConn>,
+    next_id: usize,
+}
+
+impl ScriptedListenerBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, behaviour: HandshakeBehaviour) -> usize {
+        self.push_with_addr(behaviour, None)
+    }
+
+    pub fn push_with_addr(
+        &mut self,
+        behaviour: HandshakeBehaviour,
+        remote_addr: Option<String>,
+    ) -> usize {
+        self.push_spec(behaviour, remote_addr, None)
+    }
+
+    /// Add a connection with full control over its remote addr and serve delay.
+    pub fn push_spec(
+        &mut self,
+        behaviour: HandshakeBehaviour,
+        remote_addr: Option<String>,
+        serve_delay: Option<Duration>,
+    ) -> usize {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.conns.push(ScriptedConn {
+            id,
+            behaviour,
+            remote_addr,
+            serve_delay,
+        });
+        id
+    }
+
+    /// Add `n` connections sharing one behaviour; returns their ids in order.
+    pub fn push_many(&mut self, n: usize, behaviour: HandshakeBehaviour) -> Vec<usize> {
+        (0..n).map(|_| self.push(behaviour.clone())).collect()
+    }
+
+    /// Add `n` connections sharing one behaviour and serve delay.
+    pub fn push_many_spec(
+        &mut self,
+        n: usize,
+        behaviour: HandshakeBehaviour,
+        serve_delay: Option<Duration>,
+    ) -> Vec<usize> {
+        (0..n)
+            .map(|_| self.push_spec(behaviour.clone(), None, serve_delay))
+            .collect()
+    }
+
+    /// Pre-load every connection and drop the sender so the listener idles once
+    /// drained.
+    pub fn build(self) -> ScriptedListener {
+        let (tx, rx) = unbounded_channel();
+        for conn in self.conns {
+            let _ = tx.send(conn);
+        }
+        // `tx` dropped here → `rx.recv()` yields the queued conns then `None`.
+        ScriptedListener { rx }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake handshaker
+// ---------------------------------------------------------------------------
+
+/// Handshaker that runs the per-connection [`HandshakeBehaviour`] instead of
+/// real TLS, recording completion order so tests can assert interleaving.
+#[derive(Clone, Default)]
+pub struct FakeHandshaker {
+    completion_log: Arc<Mutex<Vec<usize>>>,
+}
+
+impl FakeHandshaker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ids of connections whose handshake completed successfully, in the order
+    /// they completed.
+    pub fn completion_order(&self) -> Vec<usize> {
+        self.completion_log.lock().unwrap().clone()
+    }
+}
+
+fn fake_handshake_error() -> TlsError {
+    TlsError::IoError(io::Error::other("fake handshake failure"))
+}
+
+#[async_trait]
+impl Handshaker<ScriptedConn> for FakeHandshaker {
+    type Output = FakeServedConn;
+
+    async fn handshake(&self, raw: ScriptedConn) -> Result<Self::Output, TlsError> {
+        match raw.behaviour {
+            HandshakeBehaviour::Instant => {}
+            HandshakeBehaviour::SucceedAfter(d) => tokio::time::sleep(d).await,
+            HandshakeBehaviour::Fail => return Err(fake_handshake_error()),
+            HandshakeBehaviour::Stall => {
+                // Never resolves; cancelled by a handshake timeout (M3) or task abort.
+                future::pending::<()>().await;
+            }
+        }
+        self.completion_log.lock().unwrap().push(raw.id);
+        Ok(FakeServedConn::eof_after(raw.remote_addr, raw.serve_delay))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driving run_with
+// ---------------------------------------------------------------------------
+
+/// Trivial leaf service that always returns 200 OK — used when the serve loop's
+/// behaviour is irrelevant to the property under test (policy layer).
+#[derive(Clone)]
+pub struct OkService;
+
+impl Service<Request<Body>> for OkService {
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = future::Ready<Result<Response<Body>, Infallible>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        future::ready(Ok(Response::new(Body::from("OK"))))
+    }
+}
+
+/// Build a minimal `FeatureContext` for the harness (auth disabled, no egress).
+pub fn fake_feature_context() -> FeatureContext {
+    FeatureContext {
+        api_key_auth: false,
+        healthcheck: None,
+        healthcheck_port: None,
+        healthcheck_use_tls: None,
+        trx_logging_enabled: false,
+        forward_proxy_protocol: false,
+        trusted_headers: Vec::new(),
+        attestation_cors: None,
+        #[cfg(feature = "network_egress")]
+        egress: EgressConfig {
+            allow_list: EgressDestinations {
+                wildcard: Default::default(),
+                exact: Default::default(),
+                allow_all: Default::default(),
+                ips: Default::default(),
+            },
+        },
+        acceptor: AcceptorConfig::serial_compat(),
+    }
+}
+
+fn fake_enclave_context() -> EnclaveContext {
+    EnclaveContext::new(
+        "team_uuid".into(),
+        "app_uuid".into(),
+        "enclave_uuid".into(),
+        "my-enclave".into(),
+    )
+}
+
+/// Spawn `run_with` driven by the policy-layer fakes. The serve dependencies
+/// (a 200-OK service, fake contexts, a drained trx-log channel) are constructed
+/// internally. Returns the join handle so the test can `abort()` the (forever)
+/// loop once its assertions are done.
+pub fn spawn_policy_server(
+    listener: ScriptedListener,
+    handshaker: FakeHandshaker,
+    config: AcceptorConfig,
+    metrics: Arc<AcceptMetrics>,
+) -> JoinHandle<()> {
+    // Keep the trx-log receiver alive + drained so any `tx.send` succeeds.
+    let (tx, mut rx): (UnboundedSender<LogHandlerMessage>, _) = unbounded_channel();
+    tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let enclave_context = Arc::new(fake_enclave_context());
+    let feature_context = Arc::new(fake_feature_context());
+    let e3_client = Arc::new(E3Client::new());
+
+    tokio::spawn(async move {
+        let _ = run_with(
+            listener,
+            handshaker,
+            config,
+            OkService,
+            0,
+            enclave_context,
+            feature_context,
+            e3_client,
+            tx,
+            metrics,
+        )
+        .await;
+    })
+}
+
+/// Poll `pred` until it returns true or `timeout` elapses; returns whether it
+/// became true. Intended for *non-paused* tests (the self-test, Layer B).
+pub async fn wait_until<F: FnMut() -> bool>(mut pred: F, timeout: Duration) -> bool {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if pred() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+/// Yield repeatedly to let all *currently-runnable* tasks reach a fixed point
+/// **without advancing the (paused) clock** — `yield_now` reschedules rather
+/// than parking on a timer, so the virtual clock stays put. Use in
+/// `start_paused` tests to flush task progress after injecting work or calling
+/// `tokio::time::advance`.
+pub async fn settle() {
+    for _ in 0..200 {
+        tokio::task::yield_now().await;
+    }
+}
+
+/// Like [`settle`] but stops early once `pred` holds; returns whether it did.
+/// Does not advance the clock, so a predicate that only becomes true after time
+/// passes will return `false` (advance the clock first).
+pub async fn settle_until<F: FnMut() -> bool>(mut pred: F) -> bool {
+    for _ in 0..2000 {
+        if pred() {
+            return true;
+        }
+        tokio::task::yield_now().await;
+    }
+    pred()
+}
+
+#[cfg(test)]
+mod self_test {
+    use super::*;
+
+    // Proves the scaffolding can actually drive `run_with`: three instant
+    // connections are accepted, handshaked and served.
+    #[tokio::test]
+    async fn harness_drives_run_with() {
+        let metrics = AcceptMetrics::new();
+        let handshaker = FakeHandshaker::new();
+        let mut builder = ScriptedListenerBuilder::new();
+        builder.push_many(3, HandshakeBehaviour::Instant);
+        let listener = builder.build();
+
+        let handle = spawn_policy_server(
+            listener,
+            handshaker.clone(),
+            AcceptorConfig::serial_compat(),
+            metrics.clone(),
+        );
+
+        assert!(
+            wait_until(|| metrics.served() == 3, Duration::from_secs(5)).await,
+            "expected all 3 connections to be served, metrics = {metrics:?}"
+        );
+
+        assert_eq!(metrics.accepted(), 3);
+        assert_eq!(metrics.handshake_ok(), 3);
+        assert_eq!(metrics.served(), 3);
+        assert_eq!(handshaker.completion_order().len(), 3);
+
+        handle.abort();
+    }
+}

--- a/crates/data-plane/src/server/tls/cert_resolver.rs
+++ b/crates/data-plane/src/server/tls/cert_resolver.rs
@@ -356,6 +356,7 @@ impl ResolvesServerCert for AttestableCertResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::tls::test_certs::{generate_ca, generate_end_cert};
     use nom::AsBytes;
     use openssl::x509::X509;
     use serial_test::serial;
@@ -661,97 +662,5 @@ mod tests {
     fn test_checking_for_trusted_hostname_false() {
         let hostname = Some("wicked_enclave.app_123543.enclaves.evervault.com");
         assert!(!AttestableCertResolver::is_trusted_cert_domain(hostname));
-    }
-
-    pub fn generate_ca() -> Result<(X509, PKey<Private>), ErrorStack> {
-        let ec_group = EcGroup::from_curve_name(Nid::SECP384R1)?;
-        let ec_key = EcKey::generate(ec_group.as_ref())?;
-        let key_pair = PKey::from_ec_key(ec_key)?;
-
-        let mut x509_name = X509NameBuilder::new()?;
-        x509_name.append_entry_by_text("C", "IE")?;
-        x509_name.append_entry_by_text("ST", "DUB")?;
-        x509_name.append_entry_by_text("O", "Evervault")?;
-        x509_name.append_entry_by_text("CN", "Data Plane Self Signed Cert")?;
-        let x509_name = x509_name.build();
-
-        let mut cert_builder = X509::builder()?;
-        cert_builder.set_version(2)?;
-        let serial_number = {
-            let mut serial = BigNum::new()?;
-            serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
-            serial.to_asn1_integer()?
-        };
-
-        cert_builder.set_serial_number(&serial_number)?;
-        cert_builder.set_subject_name(&x509_name)?;
-        cert_builder.set_issuer_name(&x509_name)?;
-        cert_builder.set_pubkey(&key_pair)?;
-        let not_before = Asn1Time::days_from_now(0)?;
-        cert_builder.set_not_before(&not_before)?;
-        let not_after = Asn1Time::days_from_now(365)?;
-        cert_builder.set_not_after(&not_after)?;
-
-        cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
-        cert_builder.append_extension(
-            KeyUsage::new()
-                .critical()
-                .key_cert_sign()
-                .crl_sign()
-                .build()?,
-        )?;
-
-        let subject_key_identifier =
-            SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
-        cert_builder.append_extension(subject_key_identifier)?;
-
-        cert_builder.sign(&key_pair, MessageDigest::sha256())?;
-        let cert = cert_builder.build();
-        Ok((cert, key_pair))
-    }
-
-    pub fn generate_cert() -> Result<(X509, PKey<Private>), ErrorStack> {
-        let ec_group = EcGroup::from_curve_name(Nid::SECP384R1)?;
-        let ec_key = EcKey::generate(ec_group.as_ref())?;
-        let key_pair = PKey::from_ec_key(ec_key)?;
-
-        let mut x509_name = X509NameBuilder::new()?;
-        x509_name.append_entry_by_text("C", "IE")?;
-        x509_name.append_entry_by_text("ST", "DUB")?;
-        x509_name.append_entry_by_text("O", "Evervault")?;
-        x509_name.append_entry_by_text("CN", "test_enclave.app123654.enclave.evervault.dev")?;
-        let x509_name = x509_name.build();
-
-        let mut cert_builder = X509::builder()?;
-        cert_builder.set_version(2)?;
-        let serial_number = {
-            let mut serial = BigNum::new()?;
-            serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
-            serial.to_asn1_integer()?
-        };
-
-        cert_builder.set_serial_number(&serial_number)?;
-        cert_builder.set_subject_name(&x509_name)?;
-        cert_builder.set_issuer_name(&x509_name)?;
-        cert_builder.set_pubkey(&key_pair)?;
-        let not_before = Asn1Time::days_from_now(0)?;
-        cert_builder.set_not_before(&not_before)?;
-        let not_after = Asn1Time::days_from_now(365)?;
-        cert_builder.set_not_after(&not_after)?;
-
-        cert_builder.sign(&key_pair, MessageDigest::sha256())?;
-        let cert = cert_builder.build();
-
-        Ok((cert, key_pair))
-    }
-
-    pub fn generate_end_cert() -> CertifiedKey {
-        let (cert, key) = generate_cert().unwrap();
-        let der_encoded_private_key = key.private_key_to_der().unwrap();
-        let ecdsa_private_key = sign::any_ecdsa_type(&PrivateKey(der_encoded_private_key)).unwrap();
-        let pem_encoded_cert: Vec<u8> = cert.to_pem().unwrap();
-        let parsed_pem = pem::parse(&pem_encoded_cert).unwrap();
-        let cert_chain: Vec<Certificate> = vec![Certificate(parsed_pem.contents)];
-        CertifiedKey::new(cert_chain, ecdsa_private_key)
     }
 }

--- a/crates/data-plane/src/server/tls/mod.rs
+++ b/crates/data-plane/src/server/tls/mod.rs
@@ -1,4 +1,6 @@
 mod cert_resolver;
+#[cfg(test)]
+pub(crate) mod test_certs;
 mod tls_server;
 pub mod trusted_cert_container;
 pub use tls_server::*;

--- a/crates/data-plane/src/server/tls/test_certs.rs
+++ b/crates/data-plane/src/server/tls/test_certs.rs
@@ -1,0 +1,127 @@
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::ec::{EcGroup, EcKey};
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::{PKey, Private};
+use openssl::x509::extension::{BasicConstraints, KeyUsage, SubjectKeyIdentifier};
+use openssl::x509::{X509NameBuilder, X509};
+use tokio_rustls::rustls::sign::{self, CertifiedKey};
+use tokio_rustls::rustls::{Certificate, PrivateKey};
+
+/// Self-signed CA cert + key (used to stand in for the intermediate CA the
+/// provisioner would hand the data plane).
+pub(crate) fn generate_ca() -> Result<(X509, PKey<Private>), ErrorStack> {
+    let ec_group = EcGroup::from_curve_name(Nid::SECP384R1)?;
+    let ec_key = EcKey::generate(ec_group.as_ref())?;
+    let key_pair = PKey::from_ec_key(ec_key)?;
+
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("C", "IE")?;
+    x509_name.append_entry_by_text("ST", "DUB")?;
+    x509_name.append_entry_by_text("O", "Evervault")?;
+    x509_name.append_entry_by_text("CN", "Data Plane Self Signed Cert")?;
+    let x509_name = x509_name.build();
+
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+
+    cert_builder.set_serial_number(&serial_number)?;
+    cert_builder.set_subject_name(&x509_name)?;
+    cert_builder.set_issuer_name(&x509_name)?;
+    cert_builder.set_pubkey(&key_pair)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+    cert_builder.append_extension(
+        KeyUsage::new()
+            .critical()
+            .key_cert_sign()
+            .crl_sign()
+            .build()?,
+    )?;
+
+    let subject_key_identifier =
+        SubjectKeyIdentifier::new().build(&cert_builder.x509v3_context(None, None))?;
+    cert_builder.append_extension(subject_key_identifier)?;
+
+    cert_builder.sign(&key_pair, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+    Ok((cert, key_pair))
+}
+
+/// A standalone self-signed leaf cert + key.
+pub(crate) fn generate_cert() -> Result<(X509, PKey<Private>), ErrorStack> {
+    let ec_group = EcGroup::from_curve_name(Nid::SECP384R1)?;
+    let ec_key = EcKey::generate(ec_group.as_ref())?;
+    let key_pair = PKey::from_ec_key(ec_key)?;
+
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("C", "IE")?;
+    x509_name.append_entry_by_text("ST", "DUB")?;
+    x509_name.append_entry_by_text("O", "Evervault")?;
+    x509_name.append_entry_by_text("CN", "test_enclave.app123654.enclave.evervault.dev")?;
+    let x509_name = x509_name.build();
+
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+
+    cert_builder.set_serial_number(&serial_number)?;
+    cert_builder.set_subject_name(&x509_name)?;
+    cert_builder.set_issuer_name(&x509_name)?;
+    cert_builder.set_pubkey(&key_pair)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    cert_builder.sign(&key_pair, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+
+    Ok((cert, key_pair))
+}
+
+/// A rustls [`CertifiedKey`] for a standalone leaf cert (used to seed the
+/// trusted cert store in tests).
+pub(crate) fn generate_end_cert() -> CertifiedKey {
+    let (cert, key) = generate_cert().unwrap();
+    let der_encoded_private_key = key.private_key_to_der().unwrap();
+    let ecdsa_private_key = sign::any_ecdsa_type(&PrivateKey(der_encoded_private_key)).unwrap();
+    let pem_encoded_cert: Vec<u8> = cert.to_pem().unwrap();
+    let parsed_pem = pem::parse(&pem_encoded_cert).unwrap();
+    let cert_chain: Vec<Certificate> = vec![Certificate(parsed_pem.contents)];
+    CertifiedKey::new(cert_chain, ecdsa_private_key)
+}
+
+/// Build a real `TlsAcceptor` backed by the attestable cert resolver and a
+/// freshly-generated CA, for the end-to-end harness. Requires the global
+/// `EnclaveContext` to be seeded (the resolver reads it).
+pub(crate) fn test_tls_acceptor() -> tokio_rustls::TlsAcceptor {
+    use crate::server::tls::cert_resolver::AttestableCertResolver;
+    use std::sync::Arc;
+    use tokio_rustls::rustls::ServerConfig;
+
+    let (ca_cert, ca_key) = generate_ca().expect("generate CA");
+    let resolver =
+        AttestableCertResolver::new(ca_cert, ca_key).expect("EnclaveContext must be seeded");
+    let mut config = ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_cert_resolver(Arc::new(resolver));
+    config.alpn_protocols.push(b"http/1.1".to_vec());
+    tokio_rustls::TlsAcceptor::from(Arc::new(config))
+}

--- a/crates/data-plane/src/server/tls/tls_server.rs
+++ b/crates/data-plane/src/server/tls/tls_server.rs
@@ -65,36 +65,42 @@ pub struct WantsCert<S: Listener> {
 #[cfg(feature = "enclave")]
 pub static TRUSTED_PUB_CERT: OnceCell<Vec<u8>> = OnceCell::new();
 
-impl<S: Listener + Send + Sync> WantsCert<S> {
-    /// Get sane defaults for TLS Server config
-    fn get_base_config() -> ConfigBuilder<ServerConfig, WantsServerCert> {
-        ServerConfig::builder()
-            .with_safe_defaults()
-            .with_no_client_auth()
-    }
+/// Get sane defaults for TLS Server config
+fn get_base_config() -> ConfigBuilder<ServerConfig, WantsServerCert> {
+    ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+}
 
+pub async fn build_attestable_server_config(
+    env_loader: EnvironmentLoader<NeedCert>,
+) -> ServerResult<ServerConfig> {
+    log::info!("Building attestable TLS server config");
+
+    let (env_loader, inter_ca_cert, inter_ca_key_pair) = env_loader
+        .load_cert()
+        .await
+        .map_err(|err| TlsError::CertProvisionerError(err.to_string()))?;
+
+    #[cfg(feature = "enclave")]
+    let _: Option<CertifiedKey> = enclave_trusted_cert().await;
+
+    // Once intermediate cert and trusted cert retrieved, write cage initialised vars
+    env_loader.finalize_env().unwrap();
+
+    let inter_ca_resolver = AttestableCertResolver::new(inter_ca_cert, inter_ca_key_pair)?;
+    let mut tls_config = get_base_config().with_cert_resolver(Arc::new(inter_ca_resolver));
+    tls_config.alpn_protocols.push(b"http/1.1".to_vec());
+    tls_config.alpn_protocols.push(b"h2".to_vec());
+    Ok(tls_config)
+}
+
+impl<S: Listener + Send + Sync> WantsCert<S> {
     pub async fn with_attestable_cert(
         self,
         env_loader: EnvironmentLoader<NeedCert>,
     ) -> ServerResult<TlsServer<S>> {
-        log::info!("Creating TLSServer with attestable cert");
-
-        let (env_loader, inter_ca_cert, inter_ca_key_pair) = env_loader
-            .load_cert()
-            .await
-            .map_err(|err| TlsError::CertProvisionerError(err.to_string()))?;
-
-        #[cfg(feature = "enclave")]
-        let _: Option<CertifiedKey> = enclave_trusted_cert().await;
-
-        // Once intermediate cert and trusted cert retrieved, write cage initialised vars
-        env_loader.finalize_env().unwrap();
-
-        let inter_ca_resolver = AttestableCertResolver::new(inter_ca_cert, inter_ca_key_pair)?;
-        let mut tls_config =
-            Self::get_base_config().with_cert_resolver(Arc::new(inter_ca_resolver));
-        tls_config.alpn_protocols.push(b"http/1.1".to_vec());
-        tls_config.alpn_protocols.push(b"h2".to_vec());
+        let tls_config = build_attestable_server_config(env_loader).await?;
         Ok(TlsServer::new(tls_config, self.tcp_server))
     }
 }

--- a/crates/shared/src/logging.rs
+++ b/crates/shared/src/logging.rs
@@ -25,8 +25,10 @@ pub struct TrxContext {
     txid: String,
     ts: String,
     msg: String,
+    #[builder(default)]
     uri: Option<String>,
     r#type: String,
+    #[builder(default)]
     request_method: Option<String>,
     #[builder(default)]
     remote_ip: Option<String>,

--- a/crates/shared/src/server/tcp.rs
+++ b/crates/shared/src/server/tcp.rs
@@ -13,6 +13,11 @@ impl TcpServer {
         let listener = TcpListener::bind(addr).await?;
         Ok(Self { inner: listener })
     }
+
+    // Expose local address for testing
+    pub fn local_addr(&self) -> std::io::Result<std::net::SocketAddr> {
+        self.inner.local_addr()
+    }
 }
 
 #[async_trait]

--- a/e2e-tests/scripts/start-data-plane.sh
+++ b/e2e-tests/scripts/start-data-plane.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo {\"api_key_auth\":${EV_API_KEY_AUTH},\"egress\":{\"allow_list\": \"jsonplaceholder.typicode.com\"},\"trx_logging_enabled\":true,\"forward_proxy_protocol\":false,\"trusted_headers\": []} > /etc/dataplane-config.json
+echo {\"api_key_auth\":${EV_API_KEY_AUTH},\"egress\":{\"allow_list\": \"jsonplaceholder.typicode.com\"},\"trx_logging_enabled\":true,\"forward_proxy_protocol\":false,\"trusted_headers\": [],\"acceptor\":{\"max_concurrent_connections\":1024,\"max_concurrent_handshakes\":64,\"handshake_timeout\":{\"secs\":10,\"nanos\":0}}} > /etc/dataplane-config.json
 
 iptables -A OUTPUT -t nat -p tcp --dport 443 ! -d 127.0.0.1  -j DNAT --to-destination 127.0.0.1:4444
 


### PR DESCRIPTION
# Why
Our current data plane implementation depends on the fact that we always have at most one request in flight in the accept loop.
The problem with that approach is that a single client stalling during the connection stalls all other connections.
Separating the accept and the TLS handshake bits to support a fully concurrent implementation.

# How
Based on the solution from https://github.com/evervault/enclaves/pull/324, I have refactored the data plane server to move the TLS and PROXY protocol handshake out of the accept loop allowing for concurrent behavior.
Introduced some metrics to the whole server flow, to make it easier to see what is going on with the connection pool.
I have also introduced a new configuration option to make the new behavior opt-in.
Got Claude to generate some tests to make sure we won't have any regressions after the change is out.
