### PR TITLE
feat(env): harden env parsing

### DIFF
--- a/crates/data-plane/src/env/mod.rs
+++ b/crates/data-plane/src/env/mod.rs
@@ -67,14 +67,7 @@ impl NeedEnv {
 
     fn write_env_file(secrets: Vec<Secret>) -> Result<(), EnvError> {
         let mut file = File::create("/etc/customer-env")?;
-
-        let env_string = secrets
-            .iter()
-            .map(|env| format!("export {}={}  ", env.name, env.secret))
-            .collect::<Vec<String>>()
-            .join("");
-
-        file.write_all(env_string.as_bytes())?;
+        file.write_all(render_env_file(&secrets).as_bytes())?;
         Ok(())
     }
 
@@ -266,16 +259,115 @@ where
     }
 }
 
+/// Single-quote a value so it is safe to `.`-source from POSIX `sh`.
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn render_env_file(secrets: &[Secret]) -> String {
+    secrets
+        .iter()
+        .filter(|env| {
+            let valid = is_valid_env_name(&env.name);
+            if !valid {
+                log::debug!(
+                    "Skipping customer environment variable with invalid name: {:?}",
+                    env.name
+                );
+            }
+            valid
+        })
+        .map(|env| format!("export {}={}\n", env.name, shell_single_quote(&env.secret)))
+        .collect()
+}
+
 pub fn write_startup_complete_env_vars() -> Result<(), Error> {
     let mut file = OpenOptions::new().append(true).open("/etc/customer-env")?;
 
-    write!(file, "export EV_INITIALIZED=true")?;
+    writeln!(file, "\nexport EV_INITIALIZED=true")?;
 
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
+    use shared::server::config_server::requests::Secret;
+
+    fn secret(name: &str, value: &str) -> Secret {
+        Secret {
+            name: name.to_string(),
+            secret: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn env_values_with_shell_metacharacters_round_trip_through_sh() {
+        // Values that broke the naive `export NAME=value` rendering: spaces,
+        // quotes, `$`, backticks and `=` would all be reparsed as shell syntax.
+        let cases = [
+            ("SIMPLE", "abc"),
+            ("WITH_SPACE", "hello world"),
+            ("WITH_SINGLE_QUOTE", "it's a secret"),
+            ("WITH_DOLLAR", "$PATH and `whoami`"),
+            ("WITH_DOUBLE_QUOTE", "a\"b\"c"),
+            ("WITH_EQUALS", "key=value=more"),
+        ];
+        // Malformed names that cannot be shell identifiers: they must be
+        // dropped, not rendered, or they would break sourcing of the file.
+        let invalid_names = ["BAD-NAME", "HAS SPACE", "1LEADING_DIGIT", "", "HAS=EQUALS"];
+
+        let mut secrets: Vec<Secret> = cases.iter().map(|(n, v)| secret(n, v)).collect();
+        secrets.extend(invalid_names.iter().map(|n| secret(n, "should_be_dropped")));
+
+        let contents = super::render_env_file(&secrets);
+
+        for name in invalid_names {
+            assert!(
+                !contents.contains(&format!("export {name}=")),
+                "invalid name {name:?} should have been dropped, got:\n{contents}"
+            );
+        }
+
+        let path = std::env::temp_dir().join(format!("customer-env-test-{}", std::process::id()));
+        std::fs::write(&path, &contents).unwrap();
+
+        // Source the file exactly like the enclave entrypoint (`. /etc/customer-env`),
+        let names: Vec<String> = cases.iter().map(|(n, _)| format!("\"${n}\"")).collect();
+        let script = format!(". '{}'; printf '%s\\0' {}", path.display(), names.join(" "));
+        let output = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .expect("failed to invoke /bin/sh");
+
+        std::fs::remove_file(&path).ok();
+
+        assert!(
+            output.status.success(),
+            "sh failed to source env file: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let got: Vec<String> = output
+            .stdout
+            .split(|b| *b == 0)
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect();
+
+        for (i, (name, expected)) in cases.iter().enumerate() {
+            assert_eq!(
+                &got[i], expected,
+                "value for {name} did not round-trip through sh sourcing"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn with_retries_redrives_requests_as_expected() {
         let responses = vec![

--- a/e2e-tests/e2e.js
+++ b/e2e-tests/e2e.js
@@ -107,6 +107,8 @@ describe("POST data to enclave", () => {
       headers: { "api-key": "placeholder" },
     });
     expect("123").to.deep.equal(result.data.ANOTHER_ENV_VAR);
+    expect("a b'c$d\"e`f").to.deep.equal(result.data.TRICKY_ENV_VAR);
+    expect(result.data.BAD_NAME).to.equal(null);
   });
 
   it("attestation doc", async () => {

--- a/e2e-tests/httpCustomerProcess.js
+++ b/e2e-tests/httpCustomerProcess.js
@@ -11,7 +11,11 @@ app.all('/hello', async (req, res) => {
 
 app.get('/env', async (req, res) => {
   try {
-    res.send({ANOTHER_ENV_VAR: process.env.ANOTHER_ENV_VAR})
+    res.send({
+      ANOTHER_ENV_VAR: process.env.ANOTHER_ENV_VAR,
+      TRICKY_ENV_VAR: process.env.TRICKY_ENV_VAR,
+      BAD_NAME: process.env["BAD-NAME"] ?? null,
+    })
   } catch (e) {
     console.log("Failed", e)
     res.status(500).send(e)

--- a/e2e-tests/mockCertProvisionerApi.js
+++ b/e2e-tests/mockCertProvisionerApi.js
@@ -80,7 +80,7 @@ tlsApp.post('/cert', async (req, res) => {
     var result = {
       intermediate_cert: ca_cert,
       key_pair: ca_key_pair,
-      secrets: [{name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}],
+      secrets: [{name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}, {name: "TRICKY_ENV_VAR", secret: "a b'c$d\"e`f"}, {name: "BAD-NAME", secret: "should_be_dropped"}],
       context: {team_uuid: "team_123", cage_uuid: "enclave_123", app_uuid: "app_12345678", cage_name: "test-enclave"},
     };
     res.status(200)
@@ -96,7 +96,7 @@ tlsApp.post('/secrets', async (req, res) => {
     
     var result = {
       context: {team_uuid: "team_123", cage_uuid: "enclave_123", app_uuid: "app_12345678", cage_name: "test-enclave"},
-      secrets: [{name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}]
+      secrets: [{name: "ANOTHER_ENV_VAR", secret: "123"}, {name: "ENCRYPTED_ENV", secret: "ev:123"}, {name: "TRICKY_ENV_VAR", secret: "a b'c$d\"e`f"}, {name: "BAD-NAME", secret: "should_be_dropped"}]
     };
     res.status(200)
     res.send(result) 

--- a/e2e-tests/noTlsTests.js
+++ b/e2e-tests/noTlsTests.js
@@ -5,5 +5,7 @@ describe('GET env from enclave', () => {
     it('returns the injected environment var', async () => {
         const result =  await axios.get('http://enclave.localhost:443/env', { headers: { 'api-key': 'placeholder' } })
         expect("123").to.deep.equal(result.data.ANOTHER_ENV_VAR)
+        expect("a b'c$d\"e`f").to.deep.equal(result.data.TRICKY_ENV_VAR)
+        expect(result.data.BAD_NAME).to.equal(null)
     });
 });


### PR DESCRIPTION
## [feat(env): harden env parsing](https://github.com/evervault/enclaves/pull/334/commits/7c569f5a389b4a6f612237a61c01723ef5dcead5)

The current implementation generates a single string with double-space-separated
`export KEY=VALUE` commands. This assumes that both the key and the value are sane,
but it is possible that they may be malformed. If that is the case, the enclave cannot
boot successfully

This commit ensures that the key is a POSIX complaint variable name, and that values
are shell-quoted.

If an env variable name is malformed, this is added to the debug logs.

## [test: add e2e tests to exercise malformed variable path](https://github.com/evervault/enclaves/pull/334/commits/55d7e8f08e0c9c57a42a6b8da11c4ab58c3d4db5)
Adds e2e tests.