### PR TITLE
Correct enclave behaviour during sustained bootstrap failure

### DIFF
--- a/crates/data-plane/src/health/agent.rs
+++ b/crates/data-plane/src/health/agent.rs
@@ -178,6 +178,20 @@ impl<C: Connect + Clone + Send + Sync + 'static> HealthcheckAgent<C> {
     }
 
     async fn perform_healthcheck(&mut self) {
+        // Checked regardless of init state — a critical service (including the boot sequence
+        // itself) can exit before the enclave ever reaches `Ready`, and that must still be
+        // reported as unhealthy rather than masked by the `Initializing` catch-all below.
+        if let Ok(exited_service) = self.shutdown_receiver.try_recv() {
+            self.exited_services.push(exited_service);
+        }
+        if !self.exited_services.is_empty() {
+            self.record_result(UserProcessHealth::Error(format!(
+                "Critical in-Enclave services have exited: {}",
+                self.serialize_exited_services()
+            )));
+            return;
+        }
+
         let hc_state = match self.state {
             HealthcheckAgentState::Initializing => self.check_user_process_initialized(),
             _ => Ok(HealthcheckAgentState::Ready),
@@ -185,18 +199,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> HealthcheckAgent<C> {
 
         let hc_result = match hc_state {
             Ok(HealthcheckAgentState::Ready) => {
-                if let Ok(exited_service) = self.shutdown_receiver.try_recv() {
-                    self.exited_services.push(exited_service);
-                    UserProcessHealth::Error(format!(
-                        "Critical in-Enclave services have exited: {}",
-                        self.serialize_exited_services()
-                    ))
-                } else if !self.exited_services.is_empty() {
-                    UserProcessHealth::Error(format!(
-                        "Critical in-Enclave services have exited: {}",
-                        self.serialize_exited_services()
-                    ))
-                } else if self.healthcheck_path.is_some() {
+                if self.healthcheck_path.is_some() {
                     self.probe_user_process(self.healthcheck_path.as_deref().unwrap())
                         .await
                 } else {

--- a/crates/data-plane/src/health/agent.rs
+++ b/crates/data-plane/src/health/agent.rs
@@ -626,4 +626,25 @@ mod test {
         let next_result = agent.buffer.iter().max().unwrap();
         assert!(next_result.is_error());
     }
+
+    #[tokio::test]
+    async fn it_fails_healthchecks_if_critical_service_has_exited_while_initializing() {
+        let client = hyper::Client::builder().build(MockHttpHealthyEmptyEndpoint::default());
+        let (mut agent, _sender, shutdown_channel) = HealthcheckAgent::new(
+            3000,
+            std::time::Duration::from_secs(1),
+            Some("/healthcheck".into()),
+            client,
+            "https".into(),
+        );
+        // agent.state defaults to HealthcheckAgentState::Initializing
+        shutdown_channel
+            .try_send(shared::notify_shutdown::Service::DataPlane)
+            .unwrap();
+
+        agent.perform_healthcheck().await;
+
+        let healthcheck_result = agent.buffer.iter().max().unwrap();
+        assert!(healthcheck_result.is_error());
+    }
 }

--- a/crates/data-plane/src/health/mod.rs
+++ b/crates/data-plane/src/health/mod.rs
@@ -8,59 +8,96 @@ use shared::bridge::{Bridge, BridgeInterface, BridgeServer, Direction};
 use shared::notify_shutdown::Service;
 use shared::server::health::{DataPlaneDiagnostic, DataPlaneState, UserProcessHealth};
 use shared::{server::Listener, ENCLAVE_HEALTH_CHECK_PORT};
-use tokio::sync::mpsc::{Sender, UnboundedSender};
+use tokio::sync::mpsc::Sender;
 
 use crate::health::agent::{HealthcheckAgent, HealthcheckStatusRequest};
 
-fn spawn_customer_healthcheck_agent(
-    customer_process_port: u16,
-    healthcheck: Option<String>,
-    use_tls: bool,
-) -> (UserProcessHealthcheckSender, Sender<Service>) {
-    let default_interval = std::time::Duration::from_secs(1);
-    if use_tls {
-        let (agent, channel, shutdown_channel) =
-            HealthcheckAgent::build_tls_agent(customer_process_port, default_interval, healthcheck);
-        tokio::spawn(async move { agent.run().await });
-        (channel, shutdown_channel)
-    } else {
-        let (agent, channel, shutdown_channel) =
-            HealthcheckAgent::build_agent(customer_process_port, default_interval, healthcheck);
-        tokio::spawn(async move { agent.run().await });
-        (channel, shutdown_channel)
+/// Handle to a running healthcheck agent. Pairs the channel used to read the user process' latest
+/// health with the channel that critical in-Enclave services use to report an unexpected exit, so
+/// that the agent can be driven and observed independently of the healthcheck server it backs.
+#[derive(Clone)]
+pub struct HealthcheckAgentHandle {
+    user_process_healthcheck_channel: UserProcessHealthcheckSender,
+    shutdown_notifier: Sender<Service>,
+}
+
+impl HealthcheckAgentHandle {
+    /// Spawn a healthcheck agent to poll the user process, returning a handle to the running agent.
+    pub fn spawn(customer_process_port: u16, healthcheck: Option<String>, use_tls: bool) -> Self {
+        let default_interval = std::time::Duration::from_secs(1);
+        let (user_process_healthcheck_channel, shutdown_notifier) = if use_tls {
+            let (agent, channel, shutdown_channel) = HealthcheckAgent::build_tls_agent(
+                customer_process_port,
+                default_interval,
+                healthcheck,
+            );
+            tokio::spawn(async move { agent.run().await });
+            (channel, shutdown_channel)
+        } else {
+            let (agent, channel, shutdown_channel) =
+                HealthcheckAgent::build_agent(customer_process_port, default_interval, healthcheck);
+            tokio::spawn(async move { agent.run().await });
+            (channel, shutdown_channel)
+        };
+
+        Self {
+            user_process_healthcheck_channel,
+            shutdown_notifier,
+        }
+    }
+
+    /// Channel used by critical in-Enclave services to notify the agent that they have exited.
+    pub fn shutdown_notifier(&self) -> Sender<Service> {
+        self.shutdown_notifier.clone()
+    }
+
+    /// Read the latest user process health recorded by the agent.
+    pub async fn check_user_process_health(&self) -> UserProcessHealth {
+        let (request, receiver) = HealthcheckStatusRequest::new();
+        if let Err(e) = self.user_process_healthcheck_channel.send(request) {
+            return UserProcessHealth::Error(format!(
+                "Failed to send healthcheck to user process on channel {e:?}"
+            ));
+        }
+
+        match receiver.await {
+            Ok(health) => health,
+            Err(e) => UserProcessHealth::Error(format!(
+                "Failed to receive healthcheck from on channel {e:?}"
+            )),
+        }
     }
 }
 
+/// Wire up the Enclave's healthcheck topology - an agent polling the user process, and a server
+/// exposing its verdict over the bridge back to the host.
 pub async fn build_health_check_server(
     customer_process_port: u16,
     healthcheck: Option<String>,
     use_tls: bool,
-) -> shared::server::error::ServerResult<(HealthcheckServer, Sender<Service>)> {
-    let (user_process_healthcheck_channel, shutdown_notifier) =
-        spawn_customer_healthcheck_agent(customer_process_port, healthcheck, use_tls);
-    let health_check_server = HealthcheckServer::new(user_process_healthcheck_channel).await?;
-    Ok((health_check_server, shutdown_notifier))
+) -> shared::server::error::ServerResult<(HealthcheckServer<BridgeServer>, HealthcheckAgentHandle)>
+{
+    let agent = HealthcheckAgentHandle::spawn(customer_process_port, healthcheck, use_tls);
+    let listener =
+        Bridge::get_listener(ENCLAVE_HEALTH_CHECK_PORT, Direction::EnclaveToHost).await?;
+    log::info!("Data plane health check server bound to port {ENCLAVE_HEALTH_CHECK_PORT}");
+    Ok((HealthcheckServer::new(agent.clone(), listener), agent))
 }
 
-pub struct HealthcheckServer {
-    user_process_healthcheck_channel: UnboundedSender<HealthcheckStatusRequest>,
-    listener: BridgeServer,
+/// Serves the Enclave's healthcheck over any accepted transport. The listener is injected so that
+/// the same server runs over the bridge in the Enclave and over loopback TCP in tests.
+pub struct HealthcheckServer<L: Listener> {
+    agent: HealthcheckAgentHandle,
+    listener: L,
 }
 
-impl HealthcheckServer {
-    async fn new(
-        user_process_healthcheck_channel: UnboundedSender<HealthcheckStatusRequest>,
-    ) -> shared::server::error::ServerResult<Self> {
-        let listener =
-            Bridge::get_listener(ENCLAVE_HEALTH_CHECK_PORT, Direction::EnclaveToHost).await?;
-        Ok(Self {
-            listener,
-            user_process_healthcheck_channel,
-        })
+impl<L: Listener> HealthcheckServer<L> {
+    pub fn new(agent: HealthcheckAgentHandle, listener: L) -> Self {
+        Self { agent, listener }
     }
 
     pub async fn run(mut self) {
-        log::info!("Data plane health check server running on port {ENCLAVE_HEALTH_CHECK_PORT}");
+        log::info!("Data plane health check server running");
         loop {
             let stream = match self.listener.accept().await {
                 Ok(stream) => stream,
@@ -70,12 +107,11 @@ impl HealthcheckServer {
                 }
             };
 
-            let user_process_channel = self.user_process_healthcheck_channel.clone();
+            let agent = self.agent.clone();
             let service = service_fn(move |_| {
-                let user_process_channel = user_process_channel.clone();
+                let agent = agent.clone();
                 async move {
-                    let user_process_health =
-                        check_user_process_health(&user_process_channel).await;
+                    let user_process_health = agent.check_user_process_health().await;
 
                     let result = DataPlaneState::Initialized(DataPlaneDiagnostic {
                         user_process: user_process_health,
@@ -96,21 +132,5 @@ impl HealthcheckServer {
                 log::error!("Data plane health check error: {error}");
             }
         }
-    }
-}
-
-async fn check_user_process_health(channel: &UserProcessHealthcheckSender) -> UserProcessHealth {
-    let (request, receiver) = HealthcheckStatusRequest::new();
-    if let Err(e) = channel.send(request) {
-        return UserProcessHealth::Error(format!(
-            "Failed to send healthcheck to user process on channel {e:?}"
-        ));
-    }
-
-    match receiver.await {
-        Ok(health) => health,
-        Err(e) => UserProcessHealth::Error(format!(
-            "Failed to receive healthcheck from on channel {e:?}"
-        )),
     }
 }

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -97,10 +97,19 @@ fn main() {
             return;
         };
 
-        tokio::select! {
-          _ = start(data_plane_port, shutdown_notifier) => {},
-          _ = health_check_server.run() => {}
-        };
+        // The health check server owns the process's lifetime — it must stay up and reachable
+        // even if the boot sequence below fails, so that the failure is reported as unhealthy
+        // rather than masked by a process exit + supervisor restart.
+        let panic_notifier = shutdown_notifier.clone();
+        let start_handle = tokio::spawn(start(data_plane_port, shutdown_notifier));
+        tokio::spawn(async move {
+            if let Err(e) = start_handle.await {
+                log::error!("Data-plane boot task exited abnormally - {e:?}");
+                let _ = panic_notifier.try_send(Service::EnvironmentLoader);
+            }
+        });
+
+        health_check_server.run().await;
     });
 }
 
@@ -127,6 +136,7 @@ async fn start(data_plane_port: u16, shutdown_notifier: Sender<Service>) {
         Ok(env_loader) => env_loader,
         Err(e) => {
             log::error!("An error occurred initializing the enclave environment - {e:?}");
+            let _ = shutdown_notifier.try_send(Service::EnvironmentLoader);
             return;
         }
     };

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -1,15 +1,16 @@
+use std::future::Future;
+
 #[cfg(feature = "network_egress")]
 use data_plane::dns::{egressproxy::EgressProxy, enclavedns::EnclaveDnsProxy};
 use data_plane::{
     crypto::api::CryptoApi,
     env::{init_environment_loader, EnvironmentLoader},
-    health::build_health_check_server,
+    health::{build_health_check_server, HealthcheckServer},
     stats::client::StatsClient,
     stats::proxy::StatsProxy,
     time::ClockSync,
     FeatureContext,
 };
-#[cfg(not(feature = "tls_termination"))]
 use shared::server::Listener;
 use shared::{
     bridge::{Bridge, BridgeInterface, Direction},
@@ -86,7 +87,7 @@ fn main() {
     };
 
     runtime.block_on(async move {
-        let Ok((health_check_server, shutdown_notifier)) = build_health_check_server(
+        let Ok((health_check_server, healthcheck_agent_handle)) = build_health_check_server(
             ctx.healthcheck_port.unwrap_or(data_plane_port),
             ctx.healthcheck,
             ctx.healthcheck_use_tls.unwrap_or(false),
@@ -97,20 +98,44 @@ fn main() {
             return;
         };
 
-        // The health check server owns the process's lifetime — it must stay up and reachable
-        // even if the boot sequence below fails, so that the failure is reported as unhealthy
-        // rather than masked by a process exit + supervisor restart.
-        let panic_notifier = shutdown_notifier.clone();
-        let start_handle = tokio::spawn(start(data_plane_port, shutdown_notifier));
-        tokio::spawn(async move {
-            if let Err(e) = start_handle.await {
-                log::error!("Data-plane boot task exited abnormally - {e:?}");
-                let _ = panic_notifier.try_send(Service::EnvironmentLoader);
-            }
-        });
-
-        health_check_server.run().await;
+        launch_service_with_healthcheck(
+            health_check_server,
+            healthcheck_agent_handle.shutdown_notifier(),
+            |shutdown_notifier: Sender<Service>| start(data_plane_port, shutdown_notifier),
+        )
+        .await;
     });
+}
+
+/// Run the Enclave's boot sequence alongside the in-Enclave healthcheck server.
+///
+/// The health check server owns the process's lifetime. It must stay up and reachable even if the
+/// boot sequence fails, so that the failure is reported as unhealthy rather than masked by a
+/// process exit + supervisor restart. `svc` is expected to run for the lifetime of the Enclave, so
+/// any exit of the boot task (clean, panicking, or cancelled) is reported to the healthcheck
+/// agent through the shutdown_notifier.
+async fn launch_service_with_healthcheck<L, Fut, F>(
+    health_check_server: HealthcheckServer<L>,
+    shutdown_notifier: Sender<Service>,
+    svc: F,
+) where
+    L: Listener,
+    Fut: Future<Output = ()> + Send + 'static,
+    F: FnOnce(Sender<Service>) -> Fut,
+{
+    let boot_notifier = shutdown_notifier.clone();
+    let start_handle = tokio::spawn(svc(shutdown_notifier));
+    tokio::spawn(async move {
+        match start_handle.await {
+            Ok(()) => log::error!("Data-plane boot task exited unexpectedly"),
+            Err(e) => log::error!("Data-plane boot task exited abnormally - {e:?}"),
+        }
+        // The boot task exiting at all leaves the Enclave without its critical services, so notify
+        // the agent regardless of how it exited.
+        let _ = boot_notifier.try_send(Service::EnvironmentLoader);
+    });
+
+    health_check_server.run().await;
 }
 
 async fn start(data_plane_port: u16, shutdown_notifier: Sender<Service>) {
@@ -267,5 +292,190 @@ async fn start_data_plane(
                 return;
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::launch_service_with_healthcheck;
+    use data_plane::health::{HealthcheckAgentHandle, HealthcheckServer};
+    use shared::notify_shutdown::{NotifyShutdown, Service};
+    use shared::server::health::{DataPlaneDiagnostic, UserProcessHealth};
+    use shared::server::TcpServer;
+    use std::future::{pending, Future};
+    use tokio::sync::mpsc::Sender;
+    use tokio::sync::oneshot;
+    use tokio::task::JoinHandle;
+    use tokio::time::Duration;
+
+    /// Matches the interval that `HealthcheckAgentHandle::spawn` gives the agent.
+    const AGENT_INTERVAL: Duration = Duration::from_secs(1);
+    /// Number of agent intervals a test will drive the paused clock through before giving up.
+    const MAX_AGENT_TICKS: usize = 5;
+
+    /// Spawn an agent with no healthcheck path so that its verdict is driven purely by the shutdown
+    /// notifications it receives, rather than by probing a user process which isn't running here.
+    fn spawn_healthcheck_agent() -> HealthcheckAgentHandle {
+        HealthcheckAgentHandle::spawn(3000, None, false)
+    }
+
+    /// A running `launch_service_with_healthcheck` backed by a live healthcheck server on loopback.
+    /// `Drop` aborts the launcher, which never returns of its own accord.
+    struct TestLaunch {
+        agent: HealthcheckAgentHandle,
+        handle: JoinHandle<()>,
+    }
+
+    impl Drop for TestLaunch {
+        fn drop(&mut self) {
+            self.handle.abort();
+        }
+    }
+
+    /// Launch `svc` behind the real healthcheck server, bound to an ephemeral loopback port. The
+    /// launcher has to be spawned rather than awaited, because a real healthcheck server loops on
+    /// `accept` forever. This is the property that we are testing.
+    async fn spawn_launch<Fut, F>(svc: F) -> TestLaunch
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+        F: FnOnce(Sender<Service>) -> Fut + Send + 'static,
+    {
+        let agent = spawn_healthcheck_agent();
+        let listener = TcpServer::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind healthcheck test listener");
+        let handle = tokio::spawn(launch_service_with_healthcheck(
+            HealthcheckServer::new(agent.clone(), listener),
+            agent.shutdown_notifier(),
+            svc,
+        ));
+        TestLaunch { agent, handle }
+    }
+
+    /// The launcher must outlive the boot sequence. If this assertions fails, it indicates that
+    /// the process exits on a boot sequence failure. This would be masked in production through
+    /// a supervisor restart instead of being reported.
+    fn assert_still_serving_healthchecks(launch: &TestLaunch) {
+        assert!(
+            !launch.handle.is_finished(),
+            "Healthcheck server stopped serving — the failure would be masked by a process exit"
+        );
+    }
+
+    /// Drive the paused clock forward an interval at a time, giving the agent a chance to perform a
+    /// healthcheck and drain any pending shutdown notifications. Returns the health reported by the
+    /// agent as soon as it goes unhealthy, or `None` if it stayed healthy for every tick.
+    async fn health_once_agent_reports_error(
+        agent: &HealthcheckAgentHandle,
+    ) -> Option<UserProcessHealth> {
+        for _ in 0..MAX_AGENT_TICKS {
+            tokio::task::yield_now().await;
+            tokio::time::advance(AGENT_INTERVAL).await;
+            let health = agent.check_user_process_health().await;
+            if health.is_error() {
+                return Some(health);
+            }
+        }
+        None
+    }
+
+    fn assert_error_names_service(health: Option<UserProcessHealth>, service: Service) {
+        let Some(UserProcessHealth::Error(message)) = health else {
+            panic!("Expected the healthcheck agent to report an error, got - {health:?}");
+        };
+        assert!(
+            message.contains(&service.to_string()),
+            "Expected the healthcheck error to name the {service} service, got - {message}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn it_remains_healthy_while_the_service_is_online() {
+        // A service which never returns, mirroring an Enclave whose critical services are all up.
+        let launch = spawn_launch(|_| pending()).await;
+
+        for _ in 0..MAX_AGENT_TICKS {
+            tokio::task::yield_now().await;
+            tokio::time::advance(AGENT_INTERVAL).await;
+            let health = launch.agent.check_user_process_health().await;
+            assert!(
+                !health.is_error(),
+                "Healthcheck agent reported an error while the service was online - {health:?}"
+            );
+            assert!(
+                DataPlaneDiagnostic {
+                    user_process: health
+                }
+                .is_healthy(),
+                "Enclave reported itself unhealthy while the service was online"
+            );
+        }
+
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn it_reports_unhealthy_when_the_service_exits_and_notifies_shutdown() {
+        // Mirrors how `start` wraps its critical services, so the exiting service is named.
+        let launch = spawn_launch(|shutdown_notifier: Sender<Service>| {
+            async {}.notify_shutdown(Service::DataPlane, shutdown_notifier)
+        })
+        .await;
+
+        let health = health_once_agent_reports_error(&launch.agent).await;
+        assert_error_names_service(health, Service::DataPlane);
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn it_reports_unhealthy_when_the_service_exits_without_notifying_shutdown() {
+        // A boot sequence which returns early without reporting the failure itself - the launcher
+        // is responsible for surfacing it, otherwise the Enclave reports healthy while running
+        // none of its critical services.
+        let launch = spawn_launch(|_| async {}).await;
+
+        let health = health_once_agent_reports_error(&launch.agent).await;
+        assert_error_names_service(health, Service::EnvironmentLoader);
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn it_reports_unhealthy_when_the_service_panics() {
+        let launch = spawn_launch(|_| async {
+            panic!("Intentional panic in the data plane boot sequence");
+        })
+        .await;
+
+        let health = health_once_agent_reports_error(&launch.agent).await;
+        assert_error_names_service(health, Service::EnvironmentLoader);
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn it_keeps_serving_healthchecks_after_the_service_panics() {
+        let (trigger_panic, panic_signal) = oneshot::channel::<()>();
+
+        let launch = spawn_launch(|_| async move {
+            let _ = panic_signal.await;
+            panic!("Intentional panic in the data plane after coming online");
+        })
+        .await;
+
+        // The Enclave is healthy while the service is online...
+        tokio::task::yield_now().await;
+        tokio::time::advance(AGENT_INTERVAL).await;
+        let health = launch.agent.check_user_process_health().await;
+        assert!(
+            !health.is_error(),
+            "Healthcheck agent reported an error before the service panicked - {health:?}"
+        );
+
+        // ...and reports unhealthy once it panics, rather than exiting the process.
+        trigger_panic
+            .send(())
+            .expect("Data plane service dropped its panic signal");
+        let health = health_once_agent_reports_error(&launch.agent).await;
+        assert_error_names_service(health, Service::EnvironmentLoader);
+        assert_still_serving_healthchecks(&launch);
     }
 }

--- a/crates/shared/src/notify_shutdown.rs
+++ b/crates/shared/src/notify_shutdown.rs
@@ -14,6 +14,7 @@ pub enum Service {
     ProvisionerProxy,
     AcmeProxy,
     ConfigServer,
+    EnvironmentLoader,
 }
 
 impl std::fmt::Display for Service {
@@ -28,6 +29,7 @@ impl std::fmt::Display for Service {
             Self::ProvisionerProxy => "provisioner-proxy",
             Self::AcmeProxy => "acme-proxy",
             Self::ConfigServer => "config-server",
+            Self::EnvironmentLoader => "environment-loader",
         };
         f.write_str(service_label)
     }


### PR DESCRIPTION
# Why

If the enclave encounters sustained failures during bootstraps, the process manager in enclave will repeatedly restart the process. This causes the host to mistake the process as initializing/bootstrapping without surfacing the failures.

# How

Restructure the entrypoint for the data plane to have the data plane notify the healthcheck service on exit. This ensures that the healthcheck is capable of recognising a failure in the bootstrap process, allowing the host correctly register as unhealthy.

This also shifts the healthcheck server's exited_services check to earlier in the logic, making sure that it is able to recognise critical services exiting even when the enclave has not initialized.

The healthcheck tooling is also adapted to make it more testable, so the crux of the Enclave launch process is now covered for the 3 primary flows:
- successful launch remains healthy
- handled error during boot is marked unhealthy
- panic during boot is marked unhealthy