### PR TITLE
Implement launcher abstraction within data plane to improve diagnostics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,3 +34,5 @@ jobs:
         uses: clechasseur/rs-clippy-check@9190480d27706dc2fd75d122753936cafafa2154 # v6.0.1
         with:
           args: --features not_enclave -- -D warnings
+      - name: Evaluate Compiler Assertions
+        run: cargo check --features compiler_assertions

--- a/crates/data-plane/Cargo.toml
+++ b/crates/data-plane/Cargo.toml
@@ -81,6 +81,7 @@ network_egress = ["shared/network_egress"]
 enclave = ["dep:tokio-vsock", "shared/enclave", "dep:rlimit"]
 not_enclave = []
 release_logging = ["log/release_max_level_info"]
+compiler_assertions = []
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(staging)'] }

--- a/crates/data-plane/src/acme/mod.rs
+++ b/crates/data-plane/src/acme/mod.rs
@@ -29,8 +29,7 @@ pub async fn get_trusted_cert() -> Result<(Vec<u8>, CertifiedKey), AcmeError> {
     let trusted_key_pair: PKey<openssl::pkey::Private> =
         AcmeKeyRetreiver::new(config_client.clone(), e3_client.clone())
             .get_or_create_enclave_key_pair()
-            .await
-            .expect("Failed to get key pair for trusted cert");
+            .await?;
 
     let cert = AcmeCertificateRetreiver::new(config_client, e3_client)
         .get_or_create_enclave_certificate(trusted_key_pair.clone(), enclave_context)

--- a/crates/data-plane/src/configuration.rs
+++ b/crates/data-plane/src/configuration.rs
@@ -29,3 +29,18 @@ pub fn get_e3_host() -> String {
 pub fn should_forward_proxy_protocol() -> bool {
     std::env::var("FORWARD_PROXY_PROTOCOL").is_ok()
 }
+
+pub const DEFAULT_TARGET_PORT: u16 = 8008;
+
+/// The data plane is invoked with the port that it needs to forward traffic to as the 
+/// only positional argument.
+/// 
+/// This function attempts to parse out a u16 value from the index 1 in the process args,
+/// returning None if parsing fails.
+pub fn parse_target_port_from_args() -> Option<u16> {
+    let mut args = std::env::args();
+    let _ = args.next(); // ignore path to executable
+    args
+      .next()
+      .and_then(|port_str| port_str.as_str().parse::<u16>().ok())
+}

--- a/crates/data-plane/src/configuration.rs
+++ b/crates/data-plane/src/configuration.rs
@@ -32,15 +32,14 @@ pub fn should_forward_proxy_protocol() -> bool {
 
 pub const DEFAULT_TARGET_PORT: u16 = 8008;
 
-/// The data plane is invoked with the port that it needs to forward traffic to as the 
+/// The data plane is invoked with the port that it needs to forward traffic to as the
 /// only positional argument.
-/// 
+///
 /// This function attempts to parse out a u16 value from the index 1 in the process args,
 /// returning None if parsing fails.
 pub fn parse_target_port_from_args() -> Option<u16> {
     let mut args = std::env::args();
     let _ = args.next(); // ignore path to executable
-    args
-      .next()
-      .and_then(|port_str| port_str.as_str().parse::<u16>().ok())
+    args.next()
+        .and_then(|port_str| port_str.as_str().parse::<u16>().ok())
 }

--- a/crates/data-plane/src/launcher/chain.rs
+++ b/crates/data-plane/src/launcher/chain.rs
@@ -1,0 +1,306 @@
+use crate::launcher::error::BootError;
+use crate::launcher::observer::BootContext;
+use crate::launcher::stage::Stage;
+use std::future::Future;
+use std::time::Instant;
+
+/// A boot sequence under construction.
+///
+/// `BootChain` is a *forward* composition: each [`then`](Self::then) wraps the accumulated future
+/// in a slightly larger one, so the chain reads in execution order and each link keeps its own
+/// output type. Contrast a `tower::Layer` stack, which nests inside-out and therefore forces the
+/// innermost service's `Response` and `Error` onto everything above it.
+///
+/// `F` is the accumulated future. It is always an opaque `impl Future`, never a
+/// `Pin<Box<dyn Future>>` — boxing would erase the `Send` bound that `tokio::spawn` needs.
+pub struct BootChain<F> {
+    ctx: BootContext,
+    fut: F,
+}
+
+impl<T: Send> BootChain<std::future::Ready<Result<T, BootError>>> {
+    /// Seed the chain with whatever the pre-chain in `main` already established, so nothing is
+    /// re-derived.
+    ///
+    /// The first two boot steps (parse argv, load `FeatureContext`) are genuinely pre-chain: the
+    /// observers cannot exist before the healthcheck agent does, and the agent cannot be built
+    /// before the config is read. Their results are handed in here instead.
+    pub fn seed(ctx: BootContext, input: T) -> Self {
+        Self {
+            ctx,
+            fut: std::future::ready(Ok(input)),
+        }
+    }
+}
+
+impl<F, T> BootChain<F>
+where
+    F: Future<Output = Result<T, BootError>> + Send,
+    T: Send,
+{
+    /// Append a stage.
+    ///
+    /// `S: Stage<In = T>` is the whole ordering guarantee: this will not compile unless `stage`
+    /// consumes exactly what the chain is currently carrying.
+    ///
+    /// The observation hooks are wired **here, once** — no stage re-implements them, and no stage
+    /// can forget to. Note there is deliberately no retry around `stage.run`: stages are not
+    /// uniformly idempotent (spawning daemons and finalizing the environment are not), so retry
+    /// belongs inside the stages that want it.
+    pub fn then<S>(
+        self,
+        stage: S,
+    ) -> BootChain<impl Future<Output = Result<S::Out, BootError>> + Send>
+    where
+        S: Stage<In = T>,
+        BootError: From<S::Error>,
+    {
+        let Self { ctx, fut: prev } = self;
+        let observed = ctx.clone();
+        let fut = async move {
+            // A failure upstream short-circuits here, so later stages never run and never report.
+            let input = prev.await?;
+            observed.on_stage_start(S::LABEL);
+            let started = Instant::now();
+            match stage.run(&observed, input).await {
+                Ok(out) => {
+                    observed.on_stage_complete(S::LABEL, started.elapsed());
+                    Ok(out)
+                }
+                Err(e) => {
+                    // The observer sees the stage's own concrete error type; widening to
+                    // `BootError` happens only afterwards.
+                    observed.on_stage_failed(S::LABEL, S::BLAME, &e);
+                    Err(BootError::from(e))
+                }
+            }
+        };
+        BootChain { ctx, fut }
+    }
+
+    /// Drive the composed sequence, yielding whatever the last stage produced.
+    ///
+    /// The chain's job is to produce a *ready-to-serve* value; the caller runs the server. A
+    /// never-completing accept loop must not be a stage, or `on_stage_complete` would never fire
+    /// and the boot would look permanently in flight.
+    pub async fn run(self) -> Result<T, BootError> {
+        self.fut.await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::env::EnvError;
+    use crate::launcher::observer::BootObserver;
+    use shared::notify_shutdown::Service;
+    use std::convert::Infallible;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Event {
+        Start(&'static str),
+        Complete(&'static str),
+        Failed(&'static str, Service, String),
+    }
+
+    #[derive(Default)]
+    struct Recorder {
+        events: Mutex<Vec<Event>>,
+    }
+
+    impl Recorder {
+        fn record(&self, event: Event) {
+            self.events.lock().unwrap().push(event);
+        }
+
+        fn labels_started(&self) -> Vec<&'static str> {
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|event| match event {
+                    Event::Start(label) => Some(*label),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    impl BootObserver for Recorder {
+        fn on_stage_start(&self, stage: &'static str) {
+            self.record(Event::Start(stage));
+        }
+
+        fn on_stage_complete(&self, stage: &'static str, _elapsed: Duration) {
+            self.record(Event::Complete(stage));
+        }
+
+        fn on_stage_failed(
+            &self,
+            stage: &'static str,
+            blame: Service,
+            error: &(dyn std::error::Error + 'static),
+        ) {
+            self.record(Event::Failed(stage, blame, error.to_string()));
+        }
+    }
+
+    /// Each test stage takes a different `In` and produces a different `Out`, so the chain below
+    /// only composes in one order.
+    struct Alpha;
+
+    impl Stage for Alpha {
+        type In = u8;
+        type Out = u16;
+        type Error = std::io::Error;
+
+        const LABEL: &'static str = "alpha";
+        const BLAME: Service = Service::ConfigServer;
+
+        async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+            Ok(u16::from(input) + 1)
+        }
+    }
+
+    struct Bravo {
+        fail: bool,
+    }
+
+    impl Stage for Bravo {
+        type In = u16;
+        type Out = u32;
+        type Error = EnvError;
+
+        const LABEL: &'static str = "bravo";
+        const BLAME: Service = Service::EnvironmentLoader;
+
+        async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+            if self.fail {
+                Err(EnvError::Crypto("bravo could not decrypt".to_string()))
+            } else {
+                Ok(u32::from(input) + 1)
+            }
+        }
+    }
+
+    /// `Error = Infallible` exercises `impl From<Infallible> for BootError` in a real composition.
+    struct Charlie {
+        ran: Arc<AtomicBool>,
+    }
+
+    impl Stage for Charlie {
+        type In = u32;
+        type Out = String;
+        type Error = Infallible;
+
+        const LABEL: &'static str = "charlie";
+        const BLAME: Service = Service::DataPlane;
+
+        async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+            self.ran.store(true, Ordering::SeqCst);
+            Ok(input.to_string())
+        }
+    }
+
+    fn context() -> (Arc<Recorder>, BootContext, Receiver<Service>) {
+        let recorder = Arc::new(Recorder::default());
+        let (notifier, receiver): (Sender<Service>, Receiver<Service>) = channel(1);
+        let ctx = BootContext::new(recorder.clone(), notifier);
+        (recorder, ctx, receiver)
+    }
+
+    #[tokio::test]
+    async fn emits_start_and_complete_once_per_stage_in_chain_order() {
+        let (recorder, ctx, _receiver) = context();
+        let ran = Arc::new(AtomicBool::new(false));
+
+        let result = BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(Bravo { fail: false })
+            .then(Charlie { ran: ran.clone() })
+            .run()
+            .await;
+
+        assert_eq!(result.unwrap(), "3");
+        assert!(ran.load(Ordering::SeqCst));
+        assert_eq!(
+            *recorder.events.lock().unwrap(),
+            vec![
+                Event::Start("alpha"),
+                Event::Complete("alpha"),
+                Event::Start("bravo"),
+                Event::Complete("bravo"),
+                Event::Start("charlie"),
+                Event::Complete("charlie"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn failing_stage_is_blamed_and_the_chain_halts() {
+        let (recorder, ctx, _receiver) = context();
+        let ran = Arc::new(AtomicBool::new(false));
+
+        let result = BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(Bravo { fail: true })
+            .then(Charlie { ran: ran.clone() })
+            .run()
+            .await;
+
+        let err = result.expect_err("the chain should surface bravo's failure");
+        assert!(matches!(err, BootError::Env(_)));
+
+        // The failure is attributed to the stage that produced it, not to a catch-all.
+        assert_eq!(
+            *recorder.events.lock().unwrap(),
+            vec![
+                Event::Start("alpha"),
+                Event::Complete("alpha"),
+                Event::Start("bravo"),
+                Event::Failed(
+                    "bravo",
+                    Service::EnvironmentLoader,
+                    "bravo could not decrypt".to_string()
+                ),
+            ]
+        );
+
+        // The chain halts: charlie is neither observed nor run.
+        assert_eq!(recorder.labels_started(), vec!["alpha", "bravo"]);
+        assert!(!ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn composed_future_is_send() {
+        fn requires_send<T: Send>(_: T) {}
+
+        let (_recorder, ctx, _receiver) = context();
+        let ran = Arc::new(AtomicBool::new(false));
+
+        // `start()` is `tokio::spawn`ed under `Fut: Future + Send + 'static`, so the whole
+        // composition has to survive that bound.
+        requires_send(
+            BootChain::seed(ctx, 1u8)
+                .then(Alpha)
+                .then(Bravo { fail: false })
+                .then(Charlie { ran })
+                .run(),
+        );
+    }
+
+    #[test]
+    fn stub_boot_future_is_send() {
+        fn requires_send<T: Send>(_: T) {}
+
+        let (_recorder, ctx, _receiver) = context();
+        requires_send(crate::launcher::stub::boot(
+            ctx,
+            crate::launcher::stub::SeedInput { target_port: 8008 },
+        ));
+    }
+}

--- a/crates/data-plane/src/launcher/chain.rs
+++ b/crates/data-plane/src/launcher/chain.rs
@@ -293,6 +293,7 @@ mod test {
         );
     }
 
+    #[cfg(feature = "compiler_assertions")]
     #[test]
     fn stub_boot_future_is_send() {
         fn requires_send<T: Send>(_: T) {}

--- a/crates/data-plane/src/launcher/chain.rs
+++ b/crates/data-plane/src/launcher/chain.rs
@@ -282,7 +282,7 @@ mod test {
         let (_recorder, ctx, _receiver) = context();
         let ran = Arc::new(AtomicBool::new(false));
 
-        // `start()` is `tokio::spawn`ed under `Fut: Future + Send + 'static`, so the whole
+        // `run()` is `tokio::spawn`ed under `Fut: Future + Send + 'static`, so the whole
         // composition has to survive that bound.
         requires_send(
             BootChain::seed(ctx, 1u8)

--- a/crates/data-plane/src/launcher/error.rs
+++ b/crates/data-plane/src/launcher/error.rs
@@ -1,0 +1,34 @@
+use std::convert::Infallible;
+use thiserror::Error;
+
+/// The chain-level error: one variant per failure mode a stage can surface.
+///
+/// Each stage keeps its *own* [`Stage::Error`](crate::launcher::Stage::Error);
+/// [`BootChain::then`](crate::launcher::BootChain::then) only requires
+/// `BootError: From<S::Error>`, so a stage's error reaches the observer at its concrete type and is
+/// widened afterwards. Nothing is flattened to `()`.
+///
+/// Follows the crate convention in [`crate::error`]: `#[from]` per source, em-dash separator, and
+/// feature-gated variants where the source itself is feature-gated. None of the sources below are
+/// feature-gated today.
+#[derive(Debug, Error)]
+pub enum BootError {
+    #[error("Failed to initialize the Enclave environment — {0}")]
+    Env(#[from] crate::env::EnvError),
+    #[error("Failed to read the Enclave context — {0}")]
+    Context(#[from] crate::ContextError),
+    #[error("Boot stage failed on IO — {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// A stage that cannot fail still has to satisfy `BootError: From<S::Error>`.
+///
+/// `Infallible` satisfies `Stage::Error`'s `std::error::Error + Send + Sync + 'static` bound, so a
+/// stage which logs-and-continues (rather than aborting boot) declares `type Error = Infallible`
+/// and needs this impl to compose. Landing it here means no later deliverable has to reach back and
+/// edit this file.
+impl From<Infallible> for BootError {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}

--- a/crates/data-plane/src/launcher/mod.rs
+++ b/crates/data-plane/src/launcher/mod.rs
@@ -1,9 +1,9 @@
 //! Scaffolding for the Enclave's boot sequence.
 //!
 //! Boot runs **once**, left-to-right, with a different output type and a different failure mode at
-//! each step. That is a forward-composed chain, not a stack of middleware — see `launcher.md` for
-//! the argument against encoding it with `tower::Service`/`Layer`, which nests inside-out and so
-//! forces every step to agree on one response type and one error type.
+//! each step. This is distinct from the tower Layer structure, supporting our boot-time logic in
+//! acting as a forward-composed chain of critical operations. This saves on the additional reverse
+//! pass from the Layer abstraction.
 //!
 //! The in-repo idiom this follows is [`shared::notify_shutdown`]: a wrapper future that observes
 //! another future's completion. [`BootChain`] applies the same trick to a *sequence*, wiring the
@@ -16,6 +16,8 @@ pub mod chain;
 pub mod error;
 pub mod observer;
 pub mod stage;
+
+#[cfg(all(not(release), feature = "compiler_assertions"))]
 pub mod stub;
 
 pub use chain::BootChain;

--- a/crates/data-plane/src/launcher/mod.rs
+++ b/crates/data-plane/src/launcher/mod.rs
@@ -1,0 +1,24 @@
+//! Scaffolding for the Enclave's boot sequence.
+//!
+//! Boot runs **once**, left-to-right, with a different output type and a different failure mode at
+//! each step. That is a forward-composed chain, not a stack of middleware — see `launcher.md` for
+//! the argument against encoding it with `tower::Service`/`Layer`, which nests inside-out and so
+//! forces every step to agree on one response type and one error type.
+//!
+//! The in-repo idiom this follows is [`shared::notify_shutdown`]: a wrapper future that observes
+//! another future's completion. [`BootChain`] applies the same trick to a *sequence*, wiring the
+//! observation hooks exactly once in [`BootChain::then`] rather than re-implementing them per stage.
+//!
+//! Nothing here is on the boot path yet. [`stub`] carries throwaway fixtures whose only job is to
+//! prove that the feature-gated chain shape typechecks in every CI feature combination.
+
+pub mod chain;
+pub mod error;
+pub mod observer;
+pub mod stage;
+pub mod stub;
+
+pub use chain::BootChain;
+pub use error::BootError;
+pub use observer::{BootContext, BootObserver, Observers};
+pub use stage::Stage;

--- a/crates/data-plane/src/launcher/observer.rs
+++ b/crates/data-plane/src/launcher/observer.rs
@@ -1,0 +1,118 @@
+use shared::notify_shutdown::Service;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::Sender;
+
+/// A sink for boot-sequence events.
+///
+/// Implementors are expected to be cheap and non-blocking: the hooks are called inline on the boot
+/// task, between stages. This is the one place in the boot abstraction that needs `dyn` — the chain
+/// itself is statically composed, but the set of observers is a runtime decision.
+pub trait BootObserver: Send + Sync + 'static {
+    /// Called immediately before a stage is polled for the first time.
+    fn on_stage_start(&self, stage: &'static str);
+    /// Called once per stage that resolves to `Ok`.
+    fn on_stage_complete(&self, stage: &'static str, elapsed: Duration);
+    /// Called once per stage that resolves to `Err`. The chain halts after this.
+    ///
+    /// `blame` is the stage's [`Stage::BLAME`](crate::launcher::Stage::BLAME) — the critical
+    /// service the healthcheck agent should name, instead of today's catch-all
+    /// `Service::EnvironmentLoader`.
+    fn on_stage_failed(
+        &self,
+        stage: &'static str,
+        blame: Service,
+        error: &(dyn std::error::Error + 'static),
+    );
+}
+
+/// Fan-out to several observers, in registration order.
+///
+/// The boot sequence wants the same events delivered to logging, to the healthcheck agent and to
+/// the shutdown notifier. Composing them here keeps [`BootContext`] holding a single `dyn`.
+#[derive(Default)]
+pub struct Observers(pub Vec<Box<dyn BootObserver>>);
+
+impl Observers {
+    pub fn new(observers: Vec<Box<dyn BootObserver>>) -> Self {
+        Self(observers)
+    }
+
+    pub fn push(&mut self, observer: Box<dyn BootObserver>) {
+        self.0.push(observer);
+    }
+}
+
+impl BootObserver for Observers {
+    fn on_stage_start(&self, stage: &'static str) {
+        for observer in &self.0 {
+            observer.on_stage_start(stage);
+        }
+    }
+
+    fn on_stage_complete(&self, stage: &'static str, elapsed: Duration) {
+        for observer in &self.0 {
+            observer.on_stage_complete(stage, elapsed);
+        }
+    }
+
+    fn on_stage_failed(
+        &self,
+        stage: &'static str,
+        blame: Service,
+        error: &(dyn std::error::Error + 'static),
+    ) {
+        for observer in &self.0 {
+            observer.on_stage_failed(stage, blame.clone(), error);
+        }
+    }
+}
+
+/// Everything a stage needs that is not its own input.
+///
+/// `Clone` is load-bearing: [`BootChain::then`](crate::launcher::BootChain::then) clones one into
+/// each stage's future. Carrying the shutdown notifier here is what lets a "spawn a daemon" stage
+/// implement the same trait as a pure transform.
+#[derive(Clone)]
+pub struct BootContext {
+    observer: Arc<dyn BootObserver>,
+    shutdown_notifier: Sender<Service>,
+}
+
+impl BootContext {
+    pub fn new(observer: Arc<dyn BootObserver>, shutdown_notifier: Sender<Service>) -> Self {
+        Self {
+            observer,
+            shutdown_notifier,
+        }
+    }
+
+    /// The channel the healthcheck agent watches for critical-service exits.
+    ///
+    /// Capacity is 1 by design — the first notification is terminal — so stages should treat a full
+    /// channel as "already reported" rather than an error.
+    pub fn shutdown_notifier(&self) -> &Sender<Service> {
+        &self.shutdown_notifier
+    }
+
+    pub fn observer(&self) -> &dyn BootObserver {
+        self.observer.as_ref()
+    }
+
+    pub fn on_stage_start(&self, stage: &'static str) {
+        self.observer.on_stage_start(stage);
+    }
+
+    pub fn on_stage_complete(&self, stage: &'static str, elapsed: Duration) {
+        self.observer.on_stage_complete(stage, elapsed);
+    }
+
+    pub fn on_stage_failed(
+        &self,
+        stage: &'static str,
+        blame: Service,
+        error: &(dyn std::error::Error + 'static),
+    ) {
+        self.observer.on_stage_failed(stage, blame, error);
+    }
+}

--- a/crates/data-plane/src/launcher/stage.rs
+++ b/crates/data-plane/src/launcher/stage.rs
@@ -13,7 +13,7 @@ use std::future::Future;
 /// `dyn`.
 ///
 /// `run` returns `impl Future<Output = _> + Send` rather than a boxed future. The `+ Send` is not
-/// decoration: the chain is driven from `start()`, which is `tokio::spawn`ed under
+/// decoration: the chain is driven from `run()`, which is `tokio::spawn`ed under
 /// `Fut: Future + Send + 'static`. Building the runtime with `new_current_thread` does **not**
 /// relax that bound — only a `LocalSet` would, and there is none in this repo. `async_trait` would
 /// erase the bound behind a `Pin<Box<dyn Future>>`, so it is not used here.

--- a/crates/data-plane/src/launcher/stage.rs
+++ b/crates/data-plane/src/launcher/stage.rs
@@ -22,8 +22,8 @@ use std::future::Future;
 ///
 /// A chain whose stages line up composes:
 ///
-/// ```
-/// use data_plane::launcher::stub::{LoadEnvironment, SeedInput, StartStatsClient};
+/// ```compile_fail
+/// // assuming some StartStatsClient and LoadEnvironment stages have been implemented...
 /// use data_plane::launcher::{BootChain, BootContext, BootError};
 ///
 /// // `StartStatsClient::Out` is `StatsClientStarted`, which is `LoadEnvironment::In`.

--- a/crates/data-plane/src/launcher/stage.rs
+++ b/crates/data-plane/src/launcher/stage.rs
@@ -1,0 +1,83 @@
+use crate::launcher::observer::BootContext;
+use shared::notify_shutdown::Service;
+use std::future::Future;
+
+/// One step of the Enclave's boot sequence.
+///
+/// Ordering is **structural**: a stage can only follow one whose `Out` is this stage's `In`. There
+/// is no separate `NextPhase` marker to keep in sync — the chain *is* the ordering, and getting it
+/// wrong is a type error rather than a runtime surprise.
+///
+/// The trait is deliberately **not object-safe** (`run` is generic in its return type, and `LABEL`
+/// / `BLAME` are associated consts). The chain is statically composed; only the observer needs
+/// `dyn`.
+///
+/// `run` returns `impl Future<Output = _> + Send` rather than a boxed future. The `+ Send` is not
+/// decoration: the chain is driven from `start()`, which is `tokio::spawn`ed under
+/// `Fut: Future + Send + 'static`. Building the runtime with `new_current_thread` does **not**
+/// relax that bound — only a `LocalSet` would, and there is none in this repo. `async_trait` would
+/// erase the bound behind a `Pin<Box<dyn Future>>`, so it is not used here.
+///
+/// # Ordering is enforced at compile time
+///
+/// A chain whose stages line up composes:
+///
+/// ```
+/// use data_plane::launcher::stub::{LoadEnvironment, SeedInput, StartStatsClient};
+/// use data_plane::launcher::{BootChain, BootContext, BootError};
+///
+/// // `StartStatsClient::Out` is `StatsClientStarted`, which is `LoadEnvironment::In`.
+/// async fn in_order(ctx: BootContext, seed: SeedInput) -> Result<(), BootError> {
+///     BootChain::seed(ctx, seed)
+///         .then(StartStatsClient)
+///         .then(LoadEnvironment)
+///         .run()
+///         .await?;
+///     Ok(())
+/// }
+/// ```
+///
+/// Swapping two stages does not. The `E0271` on the fence below records the error this is meant to
+/// produce, but note that stable rustdoc does **not** verify the code — only that the block fails
+/// to compile at all. The observed error is quoted inside the block; if you change the chain and
+/// this doctest starts passing for a different reason, that quote is what to check against.
+///
+/// ```compile_fail,E0271
+/// use data_plane::launcher::stub::{LoadEnvironment, SeedInput, StartStatsClient};
+/// use data_plane::launcher::{BootChain, BootContext, BootError};
+///
+/// // `LoadEnvironment::In` is `StatsClientStarted`, but the chain is still carrying `SeedInput`:
+/// //
+/// //   error[E0271]: type mismatch resolving `<LoadEnvironment as Stage>::In == SeedInput`
+/// //     --> src/lib.rs:6:15
+/// //      |
+/// //    6 |         .then(LoadEnvironment)
+/// //      |          ---- ^^^^^^^^^^^^^^^ expected `SeedInput`, found `StatsClientStarted`
+/// async fn out_of_order(ctx: BootContext, seed: SeedInput) -> Result<(), BootError> {
+///     BootChain::seed(ctx, seed)
+///         .then(LoadEnvironment)
+///         .then(StartStatsClient)
+///         .run()
+///         .await?;
+///     Ok(())
+/// }
+/// ```
+pub trait Stage: Send + 'static {
+    /// What the previous stage produced.
+    type In: Send;
+    /// What this stage hands to the next one.
+    type Out: Send;
+    /// Each stage keeps its own failure mode. Nothing is flattened to `()`.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Stable identifier for logs, metrics and healthcheck reporting.
+    const LABEL: &'static str;
+    /// Which critical service the healthcheck agent should blame if this stage fails.
+    const BLAME: Service;
+
+    fn run(
+        self,
+        ctx: &BootContext,
+        input: Self::In,
+    ) -> impl Future<Output = Result<Self::Out, Self::Error>> + Send;
+}

--- a/crates/data-plane/src/launcher/stub.rs
+++ b/crates/data-plane/src/launcher/stub.rs
@@ -1,0 +1,315 @@
+//! Throwaway fixtures that pin down the *shape* of the boot chain before any real stage exists.
+//!
+//! None of this is on the boot path, and none of it does real work. Its entire job is to fail
+//! `cargo check` if the feature-gated chain cannot be expressed — while the abstraction is still
+//! free to change. The stage names and the order below mirror the real sequence so that the shape
+//! being proved is the shape that will actually be built.
+//!
+//! These live outside `#[cfg(test)]` on purpose: `cargo check` does not build test code, and the
+//! eight-combination `cargo check` matrix is the gate this module exists to satisfy.
+//!
+//! # The two traps this module exists to catch
+//!
+//! **`#[cfg]` cannot go on a method call mid-chain** — expression attributes are unstable — so the
+//! chain has to be assembled with `#[cfg]`-gated `let` rebinding, which *is* stable.
+//!
+//! **The gated stages are not type-preserving.** `SourceTlsCerts` produces the intermediate CA
+//! material that the cert resolver needs, and `SourceTrustedCert` adds the ACME trusted cert on top
+//! of it, so the type the chain is carrying when it reaches the terminal stage genuinely differs
+//! across feature combinations. Rebinding alone does not fix that: `FinalizeEnv::In` has to be
+//! whatever the rebinding landed on. See [`boot`] for the resolution.
+
+use crate::env::EnvError;
+use crate::launcher::{BootChain, BootContext, BootError, Stage};
+use crate::ContextError;
+use shared::notify_shutdown::Service;
+use std::convert::Infallible;
+use std::future::Future;
+
+// ---------------------------------------------------------------------------------------------
+// The values threaded through the chain. A distinct type per link is what makes ordering
+// structural: there is exactly one order in which these compose.
+// ---------------------------------------------------------------------------------------------
+
+/// What the pre-chain in `main` already established, handed to the chain rather than re-derived.
+#[derive(Debug)]
+pub struct SeedInput {
+    pub target_port: u16,
+}
+
+#[derive(Debug)]
+pub struct StatsClientStarted {
+    pub target_port: u16,
+}
+
+#[derive(Debug)]
+pub struct EnvironmentLoaded {
+    pub target_port: u16,
+}
+
+#[derive(Debug)]
+pub struct ServicesSpawned {
+    pub target_port: u16,
+}
+
+/// The last type that every feature combination agrees on — and therefore the name the gated tails
+/// are written against.
+#[derive(Debug)]
+pub struct ListenerBound {
+    pub target_port: u16,
+}
+
+/// Stands in for `(EnvironmentLoader<Finalize>, X509, PKey<Private>)`, today's out-of-band tuple.
+#[cfg(feature = "tls_termination")]
+#[derive(Debug)]
+pub struct TlsCertsSourced {
+    pub target_port: u16,
+    pub intermediate_ca: String,
+}
+
+#[cfg(all(feature = "tls_termination", feature = "enclave"))]
+#[derive(Debug)]
+pub struct TrustedCertSourced {
+    pub target_port: u16,
+    pub intermediate_ca: String,
+    pub trusted_cert: String,
+}
+
+/// What the chain yields. The caller — not the chain — then runs the server for the process
+/// lifetime.
+#[derive(Debug)]
+pub struct ReadyToServe {
+    pub target_port: u16,
+}
+
+// ---------------------------------------------------------------------------------------------
+// The common prefix: present in every feature combination.
+// ---------------------------------------------------------------------------------------------
+
+/// `Error = Infallible` because registering the stats client logs and continues today, and must
+/// keep doing so. This is the stage that makes `impl From<Infallible> for BootError` necessary.
+pub struct StartStatsClient;
+
+impl Stage for StartStatsClient {
+    type In = SeedInput;
+    type Out = StatsClientStarted;
+    type Error = Infallible;
+
+    const LABEL: &'static str = "start-stats-client";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(StatsClientStarted {
+            target_port: input.target_port,
+        })
+    }
+}
+
+pub struct LoadEnvironment;
+
+impl Stage for LoadEnvironment {
+    type In = StatsClientStarted;
+    type Out = EnvironmentLoaded;
+    type Error = EnvError;
+
+    const LABEL: &'static str = "load-environment";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(EnvironmentLoaded {
+            target_port: input.target_port,
+        })
+    }
+}
+
+/// A stage that spawns daemons fits the same trait as a pure transform because the shutdown
+/// notifier reaches it through [`BootContext`].
+pub struct SpawnCriticalServices;
+
+impl Stage for SpawnCriticalServices {
+    type In = EnvironmentLoaded;
+    type Out = ServicesSpawned;
+    type Error = ContextError;
+
+    const LABEL: &'static str = "spawn-critical-services";
+    const BLAME: Service = Service::DataPlane;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(ServicesSpawned {
+            target_port: input.target_port,
+        })
+    }
+}
+
+pub struct BindDataPlaneListener;
+
+impl Stage for BindDataPlaneListener {
+    type In = ServicesSpawned;
+    type Out = ListenerBound;
+    type Error = std::io::Error;
+
+    const LABEL: &'static str = "bind-data-plane-listener";
+    const BLAME: Service = Service::DataPlane;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(ListenerBound {
+            target_port: input.target_port,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// The feature-gated tail stages.
+// ---------------------------------------------------------------------------------------------
+
+#[cfg(feature = "tls_termination")]
+pub struct SourceTlsCerts;
+
+#[cfg(feature = "tls_termination")]
+impl Stage for SourceTlsCerts {
+    type In = ListenerBound;
+    type Out = TlsCertsSourced;
+    type Error = EnvError;
+
+    const LABEL: &'static str = "source-tls-certs";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(TlsCertsSourced {
+            target_port: input.target_port,
+            intermediate_ca: String::new(),
+        })
+    }
+}
+
+/// The ACME trusted cert is fetched inside the TLS path today, so this stage is gated on `enclave`
+/// *within* `tls_termination` rather than on `enclave` alone.
+#[cfg(all(feature = "tls_termination", feature = "enclave"))]
+pub struct SourceTrustedCert;
+
+#[cfg(all(feature = "tls_termination", feature = "enclave"))]
+impl Stage for SourceTrustedCert {
+    type In = TlsCertsSourced;
+    type Out = TrustedCertSourced;
+    type Error = std::io::Error;
+
+    const LABEL: &'static str = "source-trusted-cert";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(TrustedCertSourced {
+            target_port: input.target_port,
+            intermediate_ca: input.intermediate_ca,
+            trusted_cert: String::new(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// The terminal stage — where Trap 2 is actually resolved.
+//
+// `FinalizeEnv` is one type with one `Out` and one `Error` in every build. What varies is its
+// `In`, which is `#[cfg]`-selected to match whatever the gated rebinding in `boot` landed on.
+// Nothing is made generic and nothing is erased: each of the three impls names a concrete type.
+// ---------------------------------------------------------------------------------------------
+
+/// Writes `EV_INITIALIZED`, unblocking the customer process. Deliberately last in every
+/// combination: it must run after both the intermediate cert and the ACME trusted cert.
+pub struct FinalizeEnv;
+
+#[cfg(all(feature = "tls_termination", feature = "enclave"))]
+impl Stage for FinalizeEnv {
+    type In = TrustedCertSourced;
+    type Out = ReadyToServe;
+    type Error = EnvError;
+
+    const LABEL: &'static str = "finalize-env";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(ReadyToServe {
+            target_port: input.target_port,
+        })
+    }
+}
+
+#[cfg(all(feature = "tls_termination", not(feature = "enclave")))]
+impl Stage for FinalizeEnv {
+    type In = TlsCertsSourced;
+    type Out = ReadyToServe;
+    type Error = EnvError;
+
+    const LABEL: &'static str = "finalize-env";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(ReadyToServe {
+            target_port: input.target_port,
+        })
+    }
+}
+
+#[cfg(not(feature = "tls_termination"))]
+impl Stage for FinalizeEnv {
+    type In = ListenerBound;
+    type Out = ReadyToServe;
+    type Error = EnvError;
+
+    const LABEL: &'static str = "finalize-env";
+    const BLAME: Service = Service::EnvironmentLoader;
+
+    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        Ok(ReadyToServe {
+            target_port: input.target_port,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Composition.
+// ---------------------------------------------------------------------------------------------
+
+/// The part of the boot sequence that is identical in every feature combination.
+///
+/// The return type names [`ListenerBound`] explicitly. That is the point: an `impl Future` whose
+/// `Output` is anonymous would leave the gated tails below with nothing to be written against, and
+/// the alternative — duplicating the whole prefix once per combination — is exactly the
+/// `#[cfg]`-duplicated impl blocks in `env/mod.rs` that this design replaces.
+///
+/// Note the chain is returned rather than run: composition stays lazy, so the prefix and the tail
+/// are still a single future.
+pub fn common_prefix(
+    ctx: BootContext,
+    seed: SeedInput,
+) -> BootChain<impl Future<Output = Result<ListenerBound, BootError>> + Send> {
+    BootChain::seed(ctx, seed)
+        .then(StartStatsClient)
+        .then(LoadEnvironment)
+        .then(SpawnCriticalServices)
+        .then(BindDataPlaneListener)
+}
+
+/// The whole boot sequence, in every feature combination.
+///
+/// `#[cfg]` sits on `let` **statements** — statement attributes are stable, expression attributes
+/// are not — so each gated stage either extends the chain or does not exist. The type the chain
+/// carries after this block is therefore `TrustedCertSourced`, `TlsCertsSourced` or `ListenerBound`
+/// depending on the build, and `FinalizeEnv` has a matching `#[cfg]`-selected `In` for each.
+pub async fn boot(ctx: BootContext, seed: SeedInput) -> Result<ReadyToServe, BootError> {
+    let chain = common_prefix(ctx, seed);
+    #[cfg(feature = "tls_termination")]
+    let chain = chain.then(SourceTlsCerts);
+    #[cfg(all(feature = "tls_termination", feature = "enclave"))]
+    let chain = chain.then(SourceTrustedCert);
+    chain.then(FinalizeEnv).run().await
+}
+
+/// Asserts, at `cargo check` time in *every* feature combination, that the composed boot future
+/// survives `tokio::spawn`'s `Fut: Future + Send + 'static` bound.
+///
+/// The equivalent test in `chain.rs` only runs in the four `not_enclave` combinations, so it cannot
+/// cover the `enclave` tails. This is never called; it exists to be type-checked.
+pub fn assert_boot_future_is_send(ctx: BootContext, seed: SeedInput) {
+    fn requires_send<T: Send + 'static>(_: T) {}
+    requires_send(boot(ctx, seed));
+}

--- a/crates/data-plane/src/lib.rs
+++ b/crates/data-plane/src/lib.rs
@@ -172,10 +172,9 @@ pub struct FeatureContext {
 }
 
 impl FeatureContext {
-    pub fn set() -> Result<(), ContextError> {
-        Self::read_dataplane_context().map(|context| {
-            FEATURE_CONTEXT.get_or_init(|| context);
-        })
+    pub fn initialize() -> Result<FeatureContext, ContextError> {
+        Self::read_dataplane_context()
+            .map(|context| FEATURE_CONTEXT.get_or_init(|| context).clone())
     }
 
     pub fn get() -> Result<FeatureContext, ContextError> {

--- a/crates/data-plane/src/lib.rs
+++ b/crates/data-plane/src/lib.rs
@@ -20,6 +20,7 @@ pub mod e3client;
 pub mod env;
 pub mod error;
 pub mod health;
+pub mod launcher;
 pub mod stats;
 pub mod time;
 pub mod utils;

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -3,11 +3,11 @@ use std::future::Future;
 #[cfg(feature = "network_egress")]
 use data_plane::dns::{egressproxy::EgressProxy, enclavedns::EnclaveDnsProxy};
 use data_plane::{
+    configuration,
     crypto::api::CryptoApi,
     env::{init_environment_loader, EnvironmentLoader},
     health::{build_health_check_server, HealthcheckServer},
-    stats::client::StatsClient,
-    stats::proxy::StatsProxy,
+    stats::{client::StatsClient, proxy::StatsProxy},
     time::ClockSync,
     FeatureContext,
 };
@@ -65,23 +65,18 @@ fn main() {
         try_show_fd_limits();
     }
 
-    let mut args = std::env::args();
-    let _ = args.next(); // ignore path to executable
-    let data_plane_port = args
-        .next()
-        .and_then(|port_str| port_str.as_str().parse::<u16>().ok())
-        .unwrap_or(8008);
+    let data_plane_port =
+        configuration::parse_target_port_from_args().unwrap_or(configuration::DEFAULT_TARGET_PORT);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("Failed to build tokio runtime in data plane");
 
-    let ctx = match FeatureContext::set() {
-        Ok(_) => FeatureContext::get()
-            .expect("Infallible - feature context read after context is set successfully"),
+    let ctx = match FeatureContext::initialize() {
+        Ok(ctx) => ctx,
         Err(e) => {
-            log::error!("Failed to set context in enclave, cannot proceed - {e:?}");
+            log::error!("Failed to initialize context in enclave, cannot proceed - {e:?}");
             return;
         }
     };

--- a/crates/data-plane/src/server/error.rs
+++ b/crates/data-plane/src/server/error.rs
@@ -30,6 +30,11 @@ pub enum TlsError {
     PemError(#[from] pem::PemError),
     #[error("CertProvisionerError - {0}")]
     CertProvisionerError(String),
+    #[cfg(feature = "enclave")]
+    #[error("TrustedCertError - Failed to get the trusted cert for the Enclave: {0}")]
+    TrustedCertError(String),
+    #[error("FinalizeEnvError - Failed to finalize the Enclave environment: {0}")]
+    FinalizeEnvError(String),
     #[error("ContextError - Failed to access Enclave context: {0}")]
     ContextError(#[from] ContextError),
     #[error("SystemTimeError - {0}")]

--- a/crates/data-plane/src/server/tls/tls_server.rs
+++ b/crates/data-plane/src/server/tls/tls_server.rs
@@ -124,30 +124,6 @@ async fn enclave_trusted_cert() -> ServerResult<CertifiedKey> {
     }
 }
 
-#[cfg(all(test, feature = "enclave"))]
-mod tests {
-    use super::*;
-
-    /// Regression test for the process kill that used to live in `enclave_trusted_cert`.
-    ///
-    /// There is no config server or ACME provider reachable from a unit test, so
-    /// `acme::get_trusted_cert` cannot succeed here. The assertion that matters is that the
-    /// failure comes back as an `Err` — before this changed, this call site ran
-    /// `std::process::exit(1)` and would have taken the test runner down with it.
-    #[tokio::test]
-    async fn failing_trusted_cert_fetch_returns_an_error_instead_of_exiting() {
-        let result =
-            tokio::time::timeout(std::time::Duration::from_secs(30), enclave_trusted_cert())
-                .await
-                .expect("Timed out waiting for the trusted cert fetch to fail");
-
-        assert!(
-            result.is_err(),
-            "Expected the trusted cert fetch to fail in a unit test environment"
-        );
-    }
-}
-
 #[async_trait]
 impl<S: Listener + Send + Sync> Listener for TlsServer<S>
 where

--- a/crates/data-plane/src/server/tls/tls_server.rs
+++ b/crates/data-plane/src/server/tls/tls_server.rs
@@ -83,10 +83,12 @@ pub async fn build_attestable_server_config(
         .map_err(|err| TlsError::CertProvisionerError(err.to_string()))?;
 
     #[cfg(feature = "enclave")]
-    let _: Option<CertifiedKey> = enclave_trusted_cert().await;
+    let _: CertifiedKey = enclave_trusted_cert().await?;
 
     // Once intermediate cert and trusted cert retrieved, write cage initialised vars
-    env_loader.finalize_env().unwrap();
+    env_loader
+        .finalize_env()
+        .map_err(|err| TlsError::FinalizeEnvError(err.to_string()))?;
 
     let inter_ca_resolver = AttestableCertResolver::new(inter_ca_cert, inter_ca_key_pair)?;
     let mut tls_config = get_base_config().with_cert_resolver(Arc::new(inter_ca_resolver));
@@ -106,19 +108,43 @@ impl<S: Listener + Send + Sync> WantsCert<S> {
 }
 
 #[cfg(feature = "enclave")]
-async fn enclave_trusted_cert() -> Option<CertifiedKey> {
+async fn enclave_trusted_cert() -> ServerResult<CertifiedKey> {
     match acme::get_trusted_cert().await {
         Ok((pub_key, trusted_cert)) => {
             let _ = TRUSTED_PUB_CERT.set(pub_key);
-            Some(trusted_cert)
+            Ok(trusted_cert)
         }
         Err(e) => {
-            //Shutdown if we can't get a trusted cert as it's required.
-            log::error!(
-                "Failed to get trusted cert for enclave. Shutting down. Cause of error: {e}"
-            );
-            std::process::exit(1);
+            // The trusted cert is required, so surface the failure to the boot task. The
+            // healthcheck server owns the process lifetime and will report the Enclave as
+            // unhealthy — the process must not exit here.
+            log::error!("Failed to get trusted cert for enclave. Cause of error: {e}");
+            Err(TlsError::TrustedCertError(e.to_string()))
         }
+    }
+}
+
+#[cfg(all(test, feature = "enclave"))]
+mod tests {
+    use super::*;
+
+    /// Regression test for the process kill that used to live in `enclave_trusted_cert`.
+    ///
+    /// There is no config server or ACME provider reachable from a unit test, so
+    /// `acme::get_trusted_cert` cannot succeed here. The assertion that matters is that the
+    /// failure comes back as an `Err` — before this changed, this call site ran
+    /// `std::process::exit(1)` and would have taken the test runner down with it.
+    #[tokio::test]
+    async fn failing_trusted_cert_fetch_returns_an_error_instead_of_exiting() {
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(30), enclave_trusted_cert())
+                .await
+                .expect("Timed out waiting for the trusted cert fetch to fail");
+
+        assert!(
+            result.is_err(),
+            "Expected the trusted cert fetch to fail in a unit test environment"
+        );
     }
 }
 

--- a/crates/shared/src/notify_shutdown.rs
+++ b/crates/shared/src/notify_shutdown.rs
@@ -15,6 +15,10 @@ pub enum Service {
     AcmeProxy,
     ConfigServer,
     EnvironmentLoader,
+    StatsClient,
+    TlsCerts,
+    TrustedCert,
+    EnvFinalize,
 }
 
 impl std::fmt::Display for Service {
@@ -30,6 +34,10 @@ impl std::fmt::Display for Service {
             Self::AcmeProxy => "acme-proxy",
             Self::ConfigServer => "config-server",
             Self::EnvironmentLoader => "environment-loader",
+            Self::StatsClient => "stats-client",
+            Self::TlsCerts => "tls-certs",
+            Self::TrustedCert => "trusted-cert",
+            Self::EnvFinalize => "env-finalize",
         };
         f.write_str(service_label)
     }
@@ -87,7 +95,76 @@ impl<F: Future> Future for NotifyShutdownFuture<F> {
 #[cfg(test)]
 mod test {
     use super::{NotifyShutdown, Service};
+    use std::collections::BTreeSet;
     use tokio::sync::mpsc::channel;
+
+    /// Every variant of [`Service`], in declaration order.
+    ///
+    /// Hand-maintained: plain Rust cannot derive a value list from an enum. The compile-time gate
+    /// is [`expected_label`] below, whose wildcard-free `match` forces every new variant to be
+    /// named and given a pinned string before the crate will build.
+    const ALL_SERVICES: &[Service] = &[
+        Service::DataPlane,
+        Service::CryptoApi,
+        Service::ClockSync,
+        Service::DnsProxy,
+        Service::EgressProxy,
+        Service::E3Proxy,
+        Service::ProvisionerProxy,
+        Service::AcmeProxy,
+        Service::ConfigServer,
+        Service::EnvironmentLoader,
+        Service::StatsClient,
+        Service::TlsCerts,
+        Service::TrustedCert,
+        Service::EnvFinalize,
+    ];
+
+    /// The label each [`Service`] variant is contracted to render.
+    ///
+    /// This `match` is exhaustive with no wildcard arm, so a variant added to [`Service`] without
+    /// a label here fails to *compile* rather than silently rendering an unchecked string. The
+    /// [`std::fmt::Display`] impl is wildcard-free for the same reason; this is a second,
+    /// independent gate on the same property, and additionally pins the exact strings.
+    fn expected_label(service: &Service) -> &'static str {
+        match service {
+            Service::DataPlane => "data-plane",
+            Service::CryptoApi => "crypto-api",
+            Service::ClockSync => "clock-sync",
+            Service::DnsProxy => "dns-proxy",
+            Service::EgressProxy => "egress-proxy",
+            Service::E3Proxy => "e3-proxy",
+            Service::ProvisionerProxy => "provisioner-proxy",
+            Service::AcmeProxy => "acme-proxy",
+            Service::ConfigServer => "config-server",
+            Service::EnvironmentLoader => "environment-loader",
+            Service::StatsClient => "stats-client",
+            Service::TlsCerts => "tls-certs",
+            Service::TrustedCert => "trusted-cert",
+            Service::EnvFinalize => "env-finalize",
+        }
+    }
+
+    #[test]
+    fn test_every_service_variant_has_a_distinct_non_empty_display_label() {
+        let mut seen_labels = BTreeSet::new();
+        for service in ALL_SERVICES {
+            let label = service.to_string();
+            assert!(
+                !label.is_empty(),
+                "{service:?} renders an empty Display label"
+            );
+            assert_eq!(
+                label,
+                expected_label(service),
+                "{service:?} does not render its contracted Display label"
+            );
+            assert!(
+                seen_labels.insert(label.clone()),
+                "Display label {label:?} is used by more than one Service variant"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn test_notify_shutdown_service_exits_tasks_as_expected() {


### PR DESCRIPTION
# Why

The data plane launch process requires many fallible steps to complete to become healthy. Each step is currently implemented independent of one another and then wired up. This is making it awkward to implement any real diagnostics during the launch process.

To make this easier, and to get better guarantees around the chain of events taking place, this PR introduces a launcher module which allows us to chain fallible async workloads in a generic manner and publish any unexpected failures to a preconfigured observer.

# How

- implement `launcher` module which adds the `Bootchain` abstraction
  - Each step in the launcher is implemented as a `Stage` trait, which accepts `In` and forwards `Out`
  - The chain is composed through a series of `then` function chains, which enforces a causal type chain `A -> B -> C`
  - The chain carries an observer which can report on stage start, end, and failure

This PR does not integrate the launcher, it is only introducing the abstraction.