### PR TITLE
Add ability for launcher stages to report diagnostics

### DIFF
--- a/crates/control-plane/src/health.rs
+++ b/crates/control-plane/src/health.rs
@@ -1,11 +1,14 @@
 use crate::error::ServerError;
 use axum::http::HeaderValue;
-use hyper::{Body, Request, Response};
+use hyper::{header, Body, Request, Response};
 use serde::{Deserialize, Serialize};
 use shared::notify_shutdown::Service;
 use shared::server::{
     error::ServerResult,
-    health::{ControlPlaneState, DataPlaneState, HealthCheck, HealthCheckLog, HealthCheckVersion},
+    health::{
+        ControlPlaneState, DataPlaneHealth, DataPlaneState, HealthCheck, HealthCheckFormat,
+        HealthCheckVersion,
+    },
     tcp::TcpServer,
     Listener,
 };
@@ -39,9 +42,9 @@ pub async fn run_ecs_health_check_service(
     if is_draining {
         let combined_log = CombinedHealthCheckLog {
             control_plane: ControlPlaneState::Draining,
-            data_plane: DataPlaneState::Unknown(
+            data_plane: DataPlaneHealth::new(DataPlaneState::Unknown(
                 "Enclave is draining, data-plane health will not be checked".into(),
-            )
+            ))
             .into(),
         };
 
@@ -53,8 +56,14 @@ pub async fn run_ecs_health_check_service(
             .body(Body::from(combined_log_json))?);
     };
 
+    // The string here is this control plane talking about an Enclave it could not reach, rather
+    // than anything the Enclave said. It reports in the newest format like every other state it
+    // synthesises; a data plane that never answered simply has no boot report to attach.
     let data_plane = health_check_data_plane().await.unwrap_or_else(|e| {
-        DataPlaneState::Error(format!("Failed to contact data-plane for healthcheck: {e}")).into()
+        DataPlaneHealth::new(DataPlaneState::Error(format!(
+            "Failed to contact data-plane for healthcheck: {e}"
+        )))
+        .into()
     });
 
     let status_to_return =
@@ -83,6 +92,11 @@ async fn health_check_data_plane() -> Result<HealthCheckVersion, ServerError> {
     let request = Request::builder()
         .method("GET")
         .header("User-Agent", "CageHealthChecker/0.0")
+        // Naming every format this control plane understands. The Enclave is almost always the
+        // older side — it can be pinned by the user, while the control plane is bumped at each deployment — so the
+        // common case is an Enclave that ignores this header and answers in whatever it has always
+        // served. To account for this `parse` is robust to arbitrary versions.
+        .header(header::ACCEPT, HealthCheckFormat::accept_header())
         .body(Body::empty())
         .expect("Cannot fail");
 
@@ -97,14 +111,7 @@ async fn health_check_data_plane() -> Result<HealthCheckVersion, ServerError> {
 
     let bytes = &hyper::body::to_bytes(response).await?;
 
-    let hc = match content_type {
-        Some("application/json;version=1") => {
-            HealthCheckVersion::V1(serde_json::from_slice::<DataPlaneState>(bytes)?)
-        }
-        _ => HealthCheckVersion::V0(serde_json::from_slice::<HealthCheckLog>(bytes)?),
-    };
-
-    Ok(hc)
+    HealthCheckVersion::parse(content_type, bytes).map_err(ServerError::from)
 }
 
 pub struct HealthCheckServer {
@@ -204,6 +211,16 @@ mod health_check_tests {
         serde_json::from_slice(&response_body).unwrap()
     }
 
+    /// States this control plane synthesises itself are reported in the newest format, so the
+    /// `dataPlane` field is v2-shaped whenever this control plane is the one answering. Reading them
+    /// back through the untagged enum is also what proves a v2 body is not misread as an older one.
+    fn expect_v2(data_plane: HealthCheckVersion) -> DataPlaneState {
+        match data_plane {
+            HealthCheckVersion::V2(health) => health.state,
+            other => panic!("Expected a v2 data plane health check, got - {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn test_enclave_health_check_service() {
         // the data-plane status should error, as its not running
@@ -214,12 +231,10 @@ mod health_check_tests {
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
 
-        let dp_state = match health_check_log.data_plane {
-            HealthCheckVersion::V0(_) => panic!("Expected V1 Version"),
-            HealthCheckVersion::V1(state) => state,
+        let DataPlaneState::Error(message) = expect_v2(health_check_log.data_plane) else {
+            panic!("Expected the control plane to report the data plane as errored");
         };
-
-        assert!(matches!(dp_state, DataPlaneState::Error(_)));
+        assert!(message.contains("Failed to contact data-plane"));
     }
 
     #[tokio::test]
@@ -233,12 +248,10 @@ mod health_check_tests {
         println!("deep response: {response:?}");
         let health_check_log = response_to_health_check_log(response).await;
 
-        let dp_state = match health_check_log.data_plane {
-            HealthCheckVersion::V0(_) => panic!("Expected V1 Version"),
-            HealthCheckVersion::V1(state) => state,
-        };
-
-        assert!(matches!(dp_state, DataPlaneState::Unknown(_)));
+        assert!(matches!(
+            expect_v2(health_check_log.data_plane),
+            DataPlaneState::Unknown(_)
+        ));
         assert!(matches!(
             health_check_log.control_plane,
             ControlPlaneState::Draining

--- a/crates/data-plane/src/health/mod.rs
+++ b/crates/data-plane/src/health/mod.rs
@@ -3,14 +3,17 @@ mod agent;
 use agent::UserProcessHealthcheckSender;
 
 use hyper::header;
-use hyper::{service::service_fn, Body, Response};
+use hyper::{service::service_fn, Body, Request, Response};
 use shared::bridge::{Bridge, BridgeInterface, BridgeServer, Direction};
 use shared::notify_shutdown::Service;
-use shared::server::health::{DataPlaneDiagnostic, DataPlaneState, UserProcessHealth};
+use shared::server::health::{
+    DataPlaneDiagnostic, DataPlaneHealth, DataPlaneState, HealthCheckFormat, UserProcessHealth,
+};
 use shared::{server::Listener, ENCLAVE_HEALTH_CHECK_PORT};
 use tokio::sync::mpsc::Sender;
 
 use crate::health::agent::{HealthcheckAgent, HealthcheckStatusRequest};
+use crate::launcher::BootJournal;
 
 /// Handle to a running healthcheck agent. Pairs the channel used to read the user process' latest
 /// health with the channel that critical in-Enclave services use to report an unexpected exit, so
@@ -71,17 +74,25 @@ impl HealthcheckAgentHandle {
 
 /// Wire up the Enclave's healthcheck topology - an agent polling the user process, and a server
 /// exposing its verdict over the bridge back to the host.
+///
+/// `boot_journal` is the read handle the server consults on each request. Whoever drives the boot
+/// sequence registers a clone of the same journal as a boot observer, so a warning raised by a
+/// stage reaches the next healthcheck body with no further plumbing.
 pub async fn build_health_check_server(
     customer_process_port: u16,
     healthcheck: Option<String>,
     use_tls: bool,
+    boot_journal: BootJournal,
 ) -> shared::server::error::ServerResult<(HealthcheckServer<BridgeServer>, HealthcheckAgentHandle)>
 {
     let agent = HealthcheckAgentHandle::spawn(customer_process_port, healthcheck, use_tls);
     let listener =
         Bridge::get_listener(ENCLAVE_HEALTH_CHECK_PORT, Direction::EnclaveToHost).await?;
     log::info!("Data plane health check server bound to port {ENCLAVE_HEALTH_CHECK_PORT}");
-    Ok((HealthcheckServer::new(agent.clone(), listener), agent))
+    Ok((
+        HealthcheckServer::new(agent.clone(), listener, boot_journal),
+        agent,
+    ))
 }
 
 /// Serves the Enclave's healthcheck over any accepted transport. The listener is injected so that
@@ -89,11 +100,16 @@ pub async fn build_health_check_server(
 pub struct HealthcheckServer<L: Listener> {
     agent: HealthcheckAgentHandle,
     listener: L,
+    boot_journal: BootJournal,
 }
 
 impl<L: Listener> HealthcheckServer<L> {
-    pub fn new(agent: HealthcheckAgentHandle, listener: L) -> Self {
-        Self { agent, listener }
+    pub fn new(agent: HealthcheckAgentHandle, listener: L, boot_journal: BootJournal) -> Self {
+        Self {
+            agent,
+            listener,
+            boot_journal,
+        }
     }
 
     pub async fn run(mut self) {
@@ -108,19 +124,44 @@ impl<L: Listener> HealthcheckServer<L> {
             };
 
             let agent = self.agent.clone();
-            let service = service_fn(move |_| {
+            let boot_journal = self.boot_journal.clone();
+            let service = service_fn(move |request: Request<Body>| {
                 let agent = agent.clone();
+                let boot_journal = boot_journal.clone();
+                // Read before the request is dropped, and answered in the caller's format rather
+                // than the newest one this data plane knows. The caller names what it can read;
+                // a body it did not ask for it cannot parse, and an unparseable body reads to the
+                // host as an Enclave that cannot be reached at all.
+                let format = HealthCheckFormat::from_accept(
+                    request
+                        .headers()
+                        .get(header::ACCEPT)
+                        .and_then(|accept| accept.to_str().ok()),
+                );
+
                 async move {
                     let user_process_health = agent.check_user_process_health().await;
 
-                    let result = DataPlaneState::Initialized(DataPlaneDiagnostic {
-                        user_process: user_process_health,
-                    });
+                    // Built once, in the format that can hold everything, then downgraded if the
+                    // caller reads an older one. The boot report is context attached to the
+                    // verdict, never part of it: the status code below stays 200 whatever boot
+                    // recorded.
+                    let health = DataPlaneHealth::new(DataPlaneState::Initialized(
+                        DataPlaneDiagnostic::new(user_process_health),
+                    ))
+                    .with_boot(boot_journal.report());
+
+                    let body = match format {
+                        HealthCheckFormat::V1 => {
+                            serde_json::to_string(&DataPlaneState::from(health))
+                        }
+                        HealthCheckFormat::V2 => serde_json::to_string(&health),
+                    };
 
                     Response::builder()
                         .status(200)
-                        .header(header::CONTENT_TYPE, "application/json;version=1")
-                        .body(Body::from(serde_json::to_string(&result).unwrap()))
+                        .header(header::CONTENT_TYPE, format.content_type())
+                        .body(Body::from(body.unwrap()))
                 }
             });
 

--- a/crates/data-plane/src/launcher/chain.rs
+++ b/crates/data-plane/src/launcher/chain.rs
@@ -56,7 +56,9 @@ where
         BootError: From<S::Error>,
     {
         let Self { ctx, fut: prev } = self;
-        let observed = ctx.clone();
+        // The stage is stamped onto the clone the stage runs with, so anything it records is
+        // attributed here rather than by the stage itself.
+        let observed = ctx.clone().for_stage(S::LABEL);
         let fut = async move {
             // A failure upstream short-circuits here, so later stages never run and never report.
             let input = prev.await?;
@@ -92,7 +94,10 @@ where
 mod test {
     use super::*;
     use crate::env::EnvError;
-    use crate::launcher::observer::BootObserver;
+    use crate::launcher::diagnostic::Diagnostic;
+    use crate::launcher::journal::BootJournal;
+    use crate::launcher::log_observer::LogObserver;
+    use crate::launcher::observer::{BootObserver, Observers, PRE_CHAIN_STAGE};
     use shared::notify_shutdown::Service;
     use std::convert::Infallible;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -105,11 +110,16 @@ mod test {
         Start(&'static str),
         Complete(&'static str),
         Failed(&'static str, Service, String),
+        /// The stage the chain attributed the diagnostic to, and the diagnostic's code.
+        Diagnostic(&'static str, &'static str),
     }
 
-    #[derive(Default)]
+    /// Records every hook onto one timeline, which is what makes the *ordering* of diagnostics
+    /// relative to start, complete and failure assertable. Clones share that timeline, so the same
+    /// recorder can be registered inside an [`Observers`] fan-out and still read from afterwards.
+    #[derive(Clone, Default)]
     struct Recorder {
-        events: Mutex<Vec<Event>>,
+        events: Arc<Mutex<Vec<Event>>>,
     }
 
     impl Recorder {
@@ -146,6 +156,10 @@ mod test {
             error: &(dyn std::error::Error + 'static),
         ) {
             self.record(Event::Failed(stage, blame, error.to_string()));
+        }
+
+        fn on_diagnostic(&self, stage: &'static str, diagnostic: &crate::launcher::Diagnostic) {
+            self.record(Event::Diagnostic(stage, diagnostic.code()));
         }
     }
 
@@ -206,11 +220,90 @@ mod test {
         }
     }
 
-    fn context() -> (Arc<Recorder>, BootContext, Receiver<Service>) {
-        let recorder = Arc::new(Recorder::default());
+    /// Records as it runs, so the diagnostic channel is exercised through a real composition rather
+    /// than by calling the observer directly. Shares `Bravo`'s input and output types, so it drops
+    /// into the same position in a chain.
+    struct Echo {
+        diagnostics: Vec<Diagnostic>,
+        fail: bool,
+    }
+
+    impl Stage for Echo {
+        type In = u16;
+        type Out = u32;
+        type Error = EnvError;
+
+        const LABEL: &'static str = "echo";
+        const BLAME: Service = Service::EnvironmentLoader;
+
+        async fn run(self, ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+            // Nothing here names "echo". Attribution comes from the chain, which is the property
+            // the tests below check.
+            for diagnostic in self.diagnostics {
+                ctx.record(diagnostic);
+            }
+
+            if self.fail {
+                Err(EnvError::Crypto("echo could not decrypt".to_string()))
+            } else {
+                Ok(u32::from(input) + 1)
+            }
+        }
+    }
+
+    /// Hands its context back to the test so a diagnostic can be recorded from a clone *after* the
+    /// stage has completed — the situation a stage which spawns a long-lived daemon creates.
+    struct Foxtrot {
+        captured: Arc<Mutex<Option<BootContext>>>,
+    }
+
+    impl Stage for Foxtrot {
+        type In = u32;
+        type Out = String;
+        type Error = Infallible;
+
+        const LABEL: &'static str = "foxtrot";
+        const BLAME: Service = Service::DataPlane;
+
+        async fn run(self, ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+            *self.captured.lock().unwrap() = Some(ctx.clone());
+            Ok(input.to_string())
+        }
+    }
+
+    fn context() -> (Recorder, BootContext, Receiver<Service>) {
+        let recorder = Recorder::default();
         let (notifier, receiver): (Sender<Service>, Receiver<Service>) = channel(1);
-        let ctx = BootContext::new(recorder.clone(), notifier);
+        let ctx = BootContext::new(Arc::new(recorder.clone()), notifier);
         (recorder, ctx, receiver)
+    }
+
+    /// A context whose observer is the real fan-out, carrying the sinks the Enclave registers.
+    ///
+    /// `on_diagnostic` is defaulted, so an `Observers` which failed to forward it would leave every
+    /// test built on `context()` passing while the channel was inert in production. At least one
+    /// test has to go through here.
+    fn fanned_out_context() -> (Recorder, BootJournal, BootContext, Receiver<Service>) {
+        let recorder = Recorder::default();
+        let journal = BootJournal::default();
+        let observers = Observers::new(vec![
+            Box::new(LogObserver),
+            Box::new(journal.clone()),
+            Box::new(recorder.clone()),
+        ]);
+        let (notifier, receiver): (Sender<Service>, Receiver<Service>) = channel(1);
+        let ctx = BootContext::new(Arc::new(observers), notifier);
+        (recorder, journal, ctx, receiver)
+    }
+
+    fn recording_echo(fail: bool) -> Echo {
+        Echo {
+            diagnostics: vec![
+                Diagnostic::info("echo.informational", "worth a log line"),
+                Diagnostic::warn("echo.degraded", "continued, but not as intended"),
+            ],
+            fail,
+        }
     }
 
     #[tokio::test]
@@ -275,6 +368,178 @@ mod test {
         assert!(!ran.load(Ordering::SeqCst));
     }
 
+    /// A succeeding stage still gets to say something, and what it says is attributed to it without
+    /// it ever naming itself.
+    #[tokio::test]
+    async fn diagnostics_are_attributed_to_the_recording_stage_and_ordered_within_it() {
+        let (recorder, ctx, _receiver) = context();
+
+        let result = BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(recording_echo(false))
+            .run()
+            .await;
+
+        assert_eq!(result.unwrap(), 3);
+        assert_eq!(
+            *recorder.events.lock().unwrap(),
+            vec![
+                Event::Start("alpha"),
+                Event::Complete("alpha"),
+                Event::Start("echo"),
+                Event::Diagnostic("echo", "echo.informational"),
+                Event::Diagnostic("echo", "echo.degraded"),
+                Event::Complete("echo"),
+            ]
+        );
+    }
+
+    /// Diagnostics recorded on the way to a failure have to reach the observer *before* the failure
+    /// does, or a reader cannot tell which of them described the run-up to it.
+    #[tokio::test]
+    async fn diagnostics_recorded_before_a_failure_land_ahead_of_it() {
+        let (recorder, ctx, _receiver) = context();
+        let ran = Arc::new(AtomicBool::new(false));
+
+        let result = BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(recording_echo(true))
+            .then(Charlie { ran: ran.clone() })
+            .run()
+            .await;
+
+        assert!(matches!(
+            result.expect_err("the chain should surface echo's failure"),
+            BootError::Env(_)
+        ));
+        assert_eq!(
+            *recorder.events.lock().unwrap(),
+            vec![
+                Event::Start("alpha"),
+                Event::Complete("alpha"),
+                Event::Start("echo"),
+                Event::Diagnostic("echo", "echo.informational"),
+                Event::Diagnostic("echo", "echo.degraded"),
+                Event::Failed(
+                    "echo",
+                    Service::EnvironmentLoader,
+                    "echo could not decrypt".to_string()
+                ),
+            ]
+        );
+        assert!(!ran.load(Ordering::SeqCst));
+    }
+
+    /// Anything recorded outside a stage is attributed to the pre-chain, rather than to whichever
+    /// stage happened to run last.
+    #[tokio::test]
+    async fn a_context_that_has_not_entered_a_stage_records_against_the_pre_chain() {
+        let (recorder, ctx, _receiver) = context();
+
+        ctx.record(Diagnostic::warn(
+            "pre.degraded",
+            "recorded before the chain started",
+        ));
+
+        assert_eq!(
+            *recorder.events.lock().unwrap(),
+            vec![Event::Diagnostic(PRE_CHAIN_STAGE, "pre.degraded")]
+        );
+    }
+
+    /// A context that outlives its stage keeps that stage's attribution instead of drifting onto a
+    /// later one. This is the accepted cost of `BootContext` being `Clone`, and it is pinned here
+    /// rather than left to be rediscovered.
+    #[tokio::test]
+    async fn a_context_clone_keeps_its_stage_after_that_stage_completes() {
+        let (recorder, ctx, _receiver) = context();
+        let captured = Arc::new(Mutex::new(None));
+
+        BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(Bravo { fail: false })
+            .then(Foxtrot {
+                captured: captured.clone(),
+            })
+            .run()
+            .await
+            .expect("the chain should succeed");
+
+        let escaped = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("foxtrot should have captured its context");
+        escaped.record(Diagnostic::warn(
+            "foxtrot.late",
+            "recorded after the stage completed",
+        ));
+
+        assert_eq!(
+            recorder.events.lock().unwrap().last(),
+            Some(&Event::Diagnostic("foxtrot", "foxtrot.late"))
+        );
+    }
+
+    #[tokio::test]
+    async fn the_observer_fan_out_delivers_diagnostics_to_every_sink() {
+        let (recorder, journal, ctx, _receiver) = fanned_out_context();
+
+        let result = BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(recording_echo(false))
+            .run()
+            .await;
+
+        assert_eq!(result.unwrap(), 3);
+
+        // Every sink is reached, in registration order and in the order the stage recorded.
+        assert_eq!(
+            *recorder.events.lock().unwrap(),
+            vec![
+                Event::Start("alpha"),
+                Event::Complete("alpha"),
+                Event::Start("echo"),
+                Event::Diagnostic("echo", "echo.informational"),
+                Event::Diagnostic("echo", "echo.degraded"),
+                Event::Complete("echo"),
+            ]
+        );
+
+        // The journal keeps the warning for export, drops the informational one, and reports no
+        // stage in flight now that the chain has finished.
+        let report = journal.report();
+        assert_eq!(report.stage, None);
+        assert_eq!(report.dropped, 0);
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(report.diagnostics[0].stage, "echo");
+        assert_eq!(report.diagnostics[0].code, "echo.degraded");
+        assert_eq!(
+            report.diagnostics[0].message,
+            "continued, but not as intended"
+        );
+    }
+
+    /// A failed boot goes on naming the stage that broke, so an operator reading the report long
+    /// after the fact still knows where it stopped.
+    #[tokio::test]
+    async fn the_journal_keeps_naming_the_stage_that_failed() {
+        let (_recorder, journal, ctx, _receiver) = fanned_out_context();
+
+        let result = BootChain::seed(ctx, 1u8)
+            .then(Alpha)
+            .then(recording_echo(true))
+            .run()
+            .await;
+
+        assert!(result.is_err());
+
+        let report = journal.report();
+        assert_eq!(report.stage.as_deref(), Some("echo"));
+        assert_eq!(report.diagnostics.len(), 1);
+        assert_eq!(report.diagnostics[0].code, "echo.degraded");
+    }
+
     #[test]
     fn composed_future_is_send() {
         fn requires_send<T: Send>(_: T) {}
@@ -285,10 +550,18 @@ mod test {
         // `run()` is `tokio::spawn`ed under `Fut: Future + Send + 'static`, so the whole
         // composition has to survive that bound.
         requires_send(
-            BootChain::seed(ctx, 1u8)
+            BootChain::seed(ctx.clone(), 1u8)
                 .then(Alpha)
                 .then(Bravo { fail: false })
                 .then(Charlie { ran })
+                .run(),
+        );
+
+        // Recording must not cost the composition its `Send`.
+        requires_send(
+            BootChain::seed(ctx, 1u8)
+                .then(Alpha)
+                .then(recording_echo(false))
                 .run(),
         );
     }

--- a/crates/data-plane/src/launcher/diagnostic.rs
+++ b/crates/data-plane/src/launcher/diagnostic.rs
@@ -1,0 +1,141 @@
+/// The longest message a diagnostic will carry. Messages are truncated at construction rather than
+/// at export, so every sink sees the same text and no sink has to defend itself against a stage
+/// that interpolated something enormous.
+pub const MAX_MESSAGE_CHARS: usize = 256;
+
+/// How far a diagnostic travels.
+///
+/// There is deliberately no `Error`. A stage that cannot continue returns `Err`, and
+/// [`BootObserver::on_stage_failed`](crate::launcher::BootObserver::on_stage_failed) already
+/// carries that error at its concrete type. A third severity would be a second route to the same
+/// place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Worth a log line, nothing more.
+    Info,
+    /// Boot continued, but not as intended. Exported in the healthcheck body.
+    Warning,
+}
+
+/// Something a stage has to say about its own progress.
+///
+/// A diagnostic is **not an outcome**. The outcome is the stage's `Ok`/`Err`, which
+/// [`BootChain`](crate::launcher::BootChain) already reports. A diagnostic carries what the outcome
+/// cannot: work skipped, degraded, repaired or retried. Without it a stage that succeeds while
+/// silently dropping something has nowhere to say so, and the Enclave boots looking perfectly
+/// healthy.
+///
+/// A diagnostic never names the stage that recorded it. The stage is stamped on by
+/// [`BootContext`](crate::launcher::BootContext), so a stage cannot misattribute its own output.
+///
+/// # NEVER PUT A VALUE IN A MESSAGE
+///
+/// Messages are serialized into the healthcheck body, which the host polls and the control plane
+/// records. **CARRY NAMES, CODES AND COUNTS. NEVER VALUES** — no environment variable contents, no
+/// decrypted secrets, no key or certificate material, no request bodies. Nothing in the type
+/// enforces this; review does.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    severity: Severity,
+    code: &'static str,
+    message: String,
+}
+
+impl Diagnostic {
+    /// Record something worth a log line and nothing more.
+    pub fn info(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(Severity::Info, code, message)
+    }
+
+    /// Record that boot continued, but not as intended.
+    pub fn warn(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(Severity::Warning, code, message)
+    }
+
+    /// `code` is `&'static str` on purpose: it is the field consumers group and alert on, so it has
+    /// to be a literal in the source — stable, greppable, and impossible to interpolate a value
+    /// into.
+    fn new(severity: Severity, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            severity,
+            code,
+            message: truncate_to_max_chars(message.into()),
+        }
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// The form diagnostics take in the log, and the reason sinks do not each invent their own.
+impl std::fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} — {}", self.code, self.message)
+    }
+}
+
+/// Truncate on a character boundary. `String::truncate` panics mid-codepoint, and a message built
+/// from a variable name is not guaranteed to be ASCII.
+fn truncate_to_max_chars(mut message: String) -> String {
+    if let Some((byte_index, _)) = message.char_indices().nth(MAX_MESSAGE_CHARS) {
+        message.truncate(byte_index);
+    }
+    message
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn severity_is_carried_through_construction() {
+        assert_eq!(
+            Diagnostic::info("some.code", "message").severity(),
+            Severity::Info
+        );
+        assert_eq!(
+            Diagnostic::warn("some.code", "message").severity(),
+            Severity::Warning
+        );
+    }
+
+    #[test]
+    fn a_message_within_the_limit_is_untouched() {
+        let message = "x".repeat(MAX_MESSAGE_CHARS);
+        let diagnostic = Diagnostic::warn("some.code", message.clone());
+        assert_eq!(diagnostic.message(), message);
+    }
+
+    #[test]
+    fn a_longer_message_is_truncated_to_the_limit() {
+        let diagnostic = Diagnostic::warn("some.code", "x".repeat(MAX_MESSAGE_CHARS + 100));
+        assert_eq!(diagnostic.message().chars().count(), MAX_MESSAGE_CHARS);
+    }
+
+    /// A message built from a variable name is not guaranteed to be ASCII, so the cut has to land
+    /// on a character boundary rather than a byte offset.
+    #[test]
+    fn a_multi_byte_message_is_truncated_on_a_character_boundary() {
+        let diagnostic = Diagnostic::warn("some.code", "é".repeat(MAX_MESSAGE_CHARS + 100));
+        assert_eq!(diagnostic.message().chars().count(), MAX_MESSAGE_CHARS);
+        assert!(diagnostic.message().chars().all(|c| c == 'é'));
+    }
+
+    #[test]
+    fn display_pairs_the_code_with_the_message() {
+        let diagnostic = Diagnostic::warn("env.malformed-variable-dropped", "dropped FOO");
+        assert_eq!(
+            diagnostic.to_string(),
+            "env.malformed-variable-dropped — dropped FOO"
+        );
+    }
+}

--- a/crates/data-plane/src/launcher/journal.rs
+++ b/crates/data-plane/src/launcher/journal.rs
@@ -1,0 +1,210 @@
+use crate::launcher::diagnostic::{Diagnostic, Severity};
+use crate::launcher::observer::BootObserver;
+use shared::notify_shutdown::Service;
+use shared::server::health::{BootDiagnostic, BootReport};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+
+/// How many warnings a report will carry.
+///
+/// Bounding is not optional. [`BootContext`](crate::launcher::BootContext) is `Clone` and reaches
+/// spawned daemons, so a clone can go on recording for the lifetime of the process long after its
+/// stage finished. The cap makes that harmless rather than a slow leak into the healthcheck body.
+const MAX_WARNINGS: usize = 32;
+
+/// Accumulates what the boot sequence recorded, and hands it to the healthcheck server.
+///
+/// The journal is both the observer the chain writes into and the read handle the health server
+/// reads out of — one shared object rather than a channel plus a store. Clones share the same
+/// state, so registering a clone as an observer and keeping another to read from is the intended
+/// use.
+///
+/// Only warnings are retained. Informational diagnostics reach the log observer and stop there:
+/// nothing polls the healthcheck body for them, and keeping them would spend the cap on entries no
+/// consumer reads.
+#[derive(Clone, Default)]
+pub struct BootJournal {
+    state: Arc<Mutex<JournalState>>,
+}
+
+#[derive(Default)]
+struct JournalState {
+    stage: Option<&'static str>,
+    warnings: Vec<BootDiagnostic>,
+    dropped: u32,
+}
+
+impl BootJournal {
+    /// The stage boot is in, or the stage it was in when it failed.
+    pub fn stage(&self) -> Option<&'static str> {
+        self.with_state(|state| state.stage)
+    }
+
+    /// Everything worth exporting, read under a single lock so that the stage, the warnings and the
+    /// dropped count always describe the same moment.
+    pub fn report(&self) -> BootReport {
+        self.with_state(|state| BootReport {
+            stage: state.stage.map(str::to_string),
+            diagnostics: state.warnings.clone(),
+            dropped: state.dropped,
+        })
+    }
+
+    /// Recovers from poisoning rather than propagating it. The healthcheck path reads the journal
+    /// on every request, and an observer hook that panicked mid-write leaves the state intact — a
+    /// slightly stale report is a far better outcome there than a panicking healthcheck.
+    fn with_state<R>(&self, read_or_write: impl FnOnce(&mut JournalState) -> R) -> R {
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        read_or_write(&mut state)
+    }
+}
+
+impl BootObserver for BootJournal {
+    fn on_stage_start(&self, stage: &'static str) {
+        self.with_state(|state| state.stage = Some(stage));
+    }
+
+    /// A chain is linear and runs once, so any completion means nothing is in flight — there is no
+    /// outer stage for the field to fall back to.
+    fn on_stage_complete(&self, _stage: &'static str, _elapsed: Duration) {
+        self.with_state(|state| state.stage = None);
+    }
+
+    /// Deliberately empty: a failure **leaves the stage set**, so the report goes on naming the
+    /// stage that broke for as long as the Enclave is up. The error itself is already carried to
+    /// the healthcheck agent by the shutdown notifier, and to the log by the log observer.
+    fn on_stage_failed(
+        &self,
+        _stage: &'static str,
+        _blame: Service,
+        _error: &(dyn std::error::Error + 'static),
+    ) {
+    }
+
+    fn on_diagnostic(&self, stage: &'static str, diagnostic: &Diagnostic) {
+        match diagnostic.severity() {
+            Severity::Info => return,
+            Severity::Warning => {}
+        }
+
+        self.with_state(|state| {
+            // First N wins: the earliest warnings are the ones that explain how boot got into
+            // whatever state produced the rest.
+            if state.warnings.len() >= MAX_WARNINGS {
+                state.dropped = state.dropped.saturating_add(1);
+                return;
+            }
+            state.warnings.push(BootDiagnostic {
+                stage: stage.to_string(),
+                code: diagnostic.code().to_string(),
+                message: diagnostic.message().to_string(),
+            });
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    fn codes(report: &BootReport) -> Vec<&str> {
+        report
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn the_in_flight_stage_is_cleared_once_it_completes() {
+        let journal = BootJournal::default();
+        assert_eq!(journal.stage(), None);
+
+        journal.on_stage_start("alpha");
+        assert_eq!(journal.stage(), Some("alpha"));
+
+        journal.on_stage_complete("alpha", Duration::from_millis(1));
+        assert_eq!(journal.stage(), None);
+    }
+
+    /// The report has to keep naming the stage that broke — that is the whole point of carrying the
+    /// stage at all.
+    #[test]
+    fn a_failing_stage_stays_named() {
+        let journal = BootJournal::default();
+
+        journal.on_stage_start("bravo");
+        journal.on_stage_failed(
+            "bravo",
+            Service::EnvironmentLoader,
+            &std::io::Error::other("bravo broke"),
+        );
+
+        assert_eq!(journal.stage(), Some("bravo"));
+        assert_eq!(journal.report().stage.as_deref(), Some("bravo"));
+    }
+
+    #[test]
+    fn warnings_are_retained_and_informational_diagnostics_are_not() {
+        let journal = BootJournal::default();
+
+        journal.on_diagnostic("bravo", &Diagnostic::info("some.info", "nothing to see"));
+        journal.on_diagnostic(
+            "bravo",
+            &Diagnostic::warn("some.warning", "something to see"),
+        );
+
+        let report = journal.report();
+        assert_eq!(codes(&report), vec!["some.warning"]);
+        assert_eq!(report.diagnostics[0].stage, "bravo");
+        assert_eq!(report.diagnostics[0].message, "something to see");
+    }
+
+    #[test]
+    fn an_empty_journal_produces_an_empty_report() {
+        assert!(BootJournal::default().report().is_empty());
+    }
+
+    #[test]
+    fn warnings_past_the_cap_are_counted_rather_than_kept() {
+        let journal = BootJournal::default();
+        let overflow = 8;
+
+        for index in 0..MAX_WARNINGS + overflow {
+            journal.on_diagnostic(
+                "bravo",
+                &Diagnostic::warn("some.warning", index.to_string()),
+            );
+        }
+
+        let report = journal.report();
+        assert_eq!(report.diagnostics.len(), MAX_WARNINGS);
+        assert_eq!(report.dropped, overflow as u32);
+
+        // First N wins, so the entries that survive are the earliest ones.
+        assert_eq!(report.diagnostics.first().unwrap().message, "0");
+        assert_eq!(
+            report.diagnostics.last().unwrap().message,
+            (MAX_WARNINGS - 1).to_string()
+        );
+    }
+
+    /// The healthcheck server reads the journal on every request, so a panic that poisoned the lock
+    /// must not turn every subsequent healthcheck into a panic too.
+    #[test]
+    fn a_poisoned_journal_still_reads() {
+        let journal = BootJournal::default();
+        journal.on_stage_start("alpha");
+        journal.on_diagnostic("alpha", &Diagnostic::warn("some.warning", "recorded"));
+
+        let panicked = catch_unwind(AssertUnwindSafe(|| {
+            journal.with_state(|_| panic!("panicked while holding the journal lock"));
+        }));
+        assert!(panicked.is_err());
+
+        let report = journal.report();
+        assert_eq!(report.stage.as_deref(), Some("alpha"));
+        assert_eq!(codes(&report), vec!["some.warning"]);
+    }
+}

--- a/crates/data-plane/src/launcher/log_observer.rs
+++ b/crates/data-plane/src/launcher/log_observer.rs
@@ -1,0 +1,45 @@
+use crate::launcher::diagnostic::{Diagnostic, Severity};
+use crate::launcher::observer::BootObserver;
+use shared::notify_shutdown::Service;
+use std::time::Duration;
+
+/// Writes the boot sequence to the Enclave's log.
+///
+/// Every line is prefixed `[boot:<stage>]`, so one boot reads as a contiguous block and a single
+/// stage can be picked out of an interleaved log:
+///
+/// ```text
+/// [boot:load-environment] started
+/// [boot:load-environment] env.malformed-variable-dropped — dropped malformed variable FOO
+/// [boot:load-environment] completed in 412ms
+/// ```
+///
+/// This is the only sink informational diagnostics reach, and the only one that sees them in the
+/// order they were recorded relative to the stages around them.
+pub struct LogObserver;
+
+impl BootObserver for LogObserver {
+    fn on_stage_start(&self, stage: &'static str) {
+        log::info!("[boot:{stage}] started");
+    }
+
+    fn on_stage_complete(&self, stage: &'static str, elapsed: Duration) {
+        log::info!("[boot:{stage}] completed in {}ms", elapsed.as_millis());
+    }
+
+    fn on_stage_failed(
+        &self,
+        stage: &'static str,
+        blame: Service,
+        error: &(dyn std::error::Error + 'static),
+    ) {
+        log::error!("[boot:{stage}] failed, blaming {blame} — {error}");
+    }
+
+    fn on_diagnostic(&self, stage: &'static str, diagnostic: &Diagnostic) {
+        match diagnostic.severity() {
+            Severity::Info => log::info!("[boot:{stage}] {diagnostic}"),
+            Severity::Warning => log::warn!("[boot:{stage}] {diagnostic}"),
+        }
+    }
+}

--- a/crates/data-plane/src/launcher/mod.rs
+++ b/crates/data-plane/src/launcher/mod.rs
@@ -13,7 +13,10 @@
 //! prove that the feature-gated chain shape typechecks in every CI feature combination.
 
 pub mod chain;
+pub mod diagnostic;
 pub mod error;
+pub mod journal;
+pub mod log_observer;
 pub mod observer;
 pub mod stage;
 
@@ -21,6 +24,9 @@ pub mod stage;
 pub mod stub;
 
 pub use chain::BootChain;
+pub use diagnostic::{Diagnostic, Severity};
 pub use error::BootError;
+pub use journal::BootJournal;
+pub use log_observer::LogObserver;
 pub use observer::{BootContext, BootObserver, Observers};
 pub use stage::Stage;

--- a/crates/data-plane/src/launcher/observer.rs
+++ b/crates/data-plane/src/launcher/observer.rs
@@ -1,3 +1,4 @@
+use crate::launcher::diagnostic::Diagnostic;
 use shared::notify_shutdown::Service;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +25,18 @@ pub trait BootObserver: Send + Sync + 'static {
         blame: Service,
         error: &(dyn std::error::Error + 'static),
     );
+
+    /// Called each time a stage records a diagnostic, in the order the stage recorded them and
+    /// interleaved with the hooks above.
+    ///
+    /// `stage` is stamped by the chain, not passed by the stage — see
+    /// [`BootContext::record`]. The diagnostic is borrowed rather than moved because every
+    /// observer in the fan-out has to see it, mirroring the `&dyn Error` in
+    /// [`on_stage_failed`](Self::on_stage_failed).
+    ///
+    /// Defaulted to a no-op so that an observer which only cares about outcomes does not have to
+    /// opt out.
+    fn on_diagnostic(&self, _stage: &'static str, _diagnostic: &Diagnostic) {}
 }
 
 /// Fan-out to several observers, in registration order.
@@ -66,7 +79,20 @@ impl BootObserver for Observers {
             observer.on_stage_failed(stage, blame.clone(), error);
         }
     }
+
+    fn on_diagnostic(&self, stage: &'static str, diagnostic: &Diagnostic) {
+        for observer in &self.0 {
+            observer.on_diagnostic(stage, diagnostic);
+        }
+    }
 }
+
+/// Who a diagnostic is attributed to when it is recorded outside any stage.
+///
+/// [`BootContext::new`] seeds the field with this so that anything recorded before the chain starts
+/// — or from a clone outliving the stage that made it — is attributed honestly rather than to
+/// whichever stage happened to run last.
+pub const PRE_CHAIN_STAGE: &str = "pre-chain";
 
 /// Everything a stage needs that is not its own input.
 ///
@@ -77,6 +103,7 @@ impl BootObserver for Observers {
 pub struct BootContext {
     observer: Arc<dyn BootObserver>,
     shutdown_notifier: Sender<Service>,
+    stage: &'static str,
 }
 
 impl BootContext {
@@ -84,7 +111,27 @@ impl BootContext {
         Self {
             observer,
             shutdown_notifier,
+            stage: PRE_CHAIN_STAGE,
         }
+    }
+
+    /// Attribute everything recorded through the returned context to `stage`.
+    ///
+    /// Called by [`BootChain::then`](crate::launcher::BootChain::then) on the clone it hands to a
+    /// stage, which is why a stage cannot name itself and therefore cannot misattribute its own
+    /// diagnostics.
+    pub fn for_stage(mut self, stage: &'static str) -> Self {
+        self.stage = stage;
+        self
+    }
+
+    /// Record a diagnostic against this context's stage.
+    ///
+    /// This is the whole of the emit side: a stage builds a [`Diagnostic`] and hands it over. Note
+    /// that a context cloned out of a stage and kept alive by a spawned daemon keeps that stage's
+    /// attribution for the lifetime of the process, because the clone is what carries the label.
+    pub fn record(&self, diagnostic: Diagnostic) {
+        self.observer.on_diagnostic(self.stage, &diagnostic);
     }
 
     /// The channel the healthcheck agent watches for critical-service exits.

--- a/crates/data-plane/src/launcher/stub.rs
+++ b/crates/data-plane/src/launcher/stub.rs
@@ -20,7 +20,7 @@
 //! whatever the rebinding landed on. See [`boot`] for the resolution.
 
 use crate::env::EnvError;
-use crate::launcher::{BootChain, BootContext, BootError, Stage};
+use crate::launcher::{BootChain, BootContext, BootError, Diagnostic, Stage};
 use crate::ContextError;
 use shared::notify_shutdown::Service;
 use std::convert::Infallible;
@@ -105,6 +105,8 @@ impl Stage for StartStatsClient {
     }
 }
 
+/// The one stage here that records diagnostics, so that the emit path is type-checked wherever the
+/// chain itself is — including the feature combinations that build no test code.
 pub struct LoadEnvironment;
 
 impl Stage for LoadEnvironment {
@@ -115,7 +117,15 @@ impl Stage for LoadEnvironment {
     const LABEL: &'static str = "load-environment";
     const BLAME: Service = Service::EnvironmentLoader;
 
-    async fn run(self, _ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+    async fn run(self, ctx: &BootContext, input: Self::In) -> Result<Self::Out, Self::Error> {
+        ctx.record(Diagnostic::info(
+            "stub.environment-not-loaded",
+            "the stub environment loader read no variables",
+        ));
+        ctx.record(Diagnostic::warn(
+            "stub.environment-not-validated",
+            "the stub environment loader validated no variables",
+        ));
         Ok(EnvironmentLoaded {
             target_port: input.target_port,
         })

--- a/crates/data-plane/src/main.rs
+++ b/crates/data-plane/src/main.rs
@@ -7,6 +7,7 @@ use data_plane::{
     crypto::api::CryptoApi,
     env::{init_environment_loader, EnvironmentLoader},
     health::{build_health_check_server, HealthcheckServer},
+    launcher::BootJournal,
     stats::{client::StatsClient, proxy::StatsProxy},
     time::ClockSync,
     FeatureContext,
@@ -82,10 +83,14 @@ fn main() {
     };
 
     runtime.block_on(async move {
+        // One journal, shared: the healthcheck server reads it, and the boot sequence records
+        // into this handle once its observers are registered.
+        let boot_journal = BootJournal::default();
         let Ok((health_check_server, healthcheck_agent_handle)) = build_health_check_server(
             ctx.healthcheck_port.unwrap_or(data_plane_port),
             ctx.healthcheck,
             ctx.healthcheck_use_tls.unwrap_or(false),
+            boot_journal.clone(),
         )
         .await
         else {
@@ -294,10 +299,19 @@ async fn start_data_plane(
 mod test {
     use super::launch_service_with_healthcheck;
     use data_plane::health::{HealthcheckAgentHandle, HealthcheckServer};
+    use data_plane::launcher::{
+        BootChain, BootContext, BootError, BootJournal, Diagnostic, LogObserver, Observers, Stage,
+    };
+    use hyper::{header, Body, Request};
     use shared::notify_shutdown::{NotifyShutdown, Service};
-    use shared::server::health::{DataPlaneDiagnostic, UserProcessHealth};
+    use shared::server::health::{
+        DataPlaneDiagnostic, DataPlaneHealth, DataPlaneState, HealthCheck, HealthCheckFormat,
+        UserProcessHealth,
+    };
     use shared::server::TcpServer;
     use std::future::{pending, Future};
+    use std::net::SocketAddr;
+    use std::sync::Arc;
     use tokio::sync::mpsc::Sender;
     use tokio::sync::oneshot;
     use tokio::task::JoinHandle;
@@ -318,6 +332,12 @@ mod test {
     /// `Drop` aborts the launcher, which never returns of its own accord.
     struct TestLaunch {
         agent: HealthcheckAgentHandle,
+        /// The journal the healthcheck server exports. Recording into it here is what a boot stage
+        /// does in the Enclave.
+        boot_journal: BootJournal,
+        /// Where the healthcheck server is listening, so that a test can read the serialized body
+        /// rather than the agent's in-process verdict.
+        address: SocketAddr,
         handle: JoinHandle<()>,
     }
 
@@ -336,15 +356,24 @@ mod test {
         F: FnOnce(Sender<Service>) -> Fut + Send + 'static,
     {
         let agent = spawn_healthcheck_agent();
+        let boot_journal = BootJournal::default();
         let listener = TcpServer::bind("127.0.0.1:0")
             .await
             .expect("Failed to bind healthcheck test listener");
+        let address = listener
+            .local_addr()
+            .expect("Failed to read the healthcheck test listener's address");
         let handle = tokio::spawn(launch_service_with_healthcheck(
-            HealthcheckServer::new(agent.clone(), listener),
+            HealthcheckServer::new(agent.clone(), listener, boot_journal.clone()),
             agent.shutdown_notifier(),
             svc,
         ));
-        TestLaunch { agent, handle }
+        TestLaunch {
+            agent,
+            boot_journal,
+            address,
+            handle,
+        }
     }
 
     /// The launcher must outlive the boot sequence. If this assertions fails, it indicates that
@@ -398,10 +427,7 @@ mod test {
                 "Healthcheck agent reported an error while the service was online - {health:?}"
             );
             assert!(
-                DataPlaneDiagnostic {
-                    user_process: health
-                }
-                .is_healthy(),
+                DataPlaneDiagnostic::new(health).is_healthy(),
                 "Enclave reported itself unhealthy while the service was online"
             );
         }
@@ -472,5 +498,268 @@ mod test {
         let health = health_once_agent_reports_error(&launch.agent).await;
         assert_error_names_service(health, Service::EnvironmentLoader);
         assert_still_serving_healthchecks(&launch);
+    }
+
+    /// Stands in for a real boot stage: it records as it goes, and either succeeds or fails. The
+    /// label is a real stage name so that the body under test reads the way a production one will.
+    struct LoadEnvironment {
+        fail: bool,
+    }
+
+    impl Stage for LoadEnvironment {
+        type In = ();
+        type Out = ();
+        type Error = std::io::Error;
+
+        const LABEL: &'static str = "load-environment";
+        const BLAME: Service = Service::EnvironmentLoader;
+
+        async fn run(self, ctx: &BootContext, _input: Self::In) -> Result<Self::Out, Self::Error> {
+            ctx.record(Diagnostic::info(
+                "env.secrets-decrypted",
+                "decrypted 4 environment variables",
+            ));
+            ctx.record(Diagnostic::warn(
+                "env.malformed-variable-dropped",
+                "dropped 1 malformed environment variable",
+            ));
+
+            if self.fail {
+                Err(std::io::Error::other(
+                    "could not write the environment file",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Run a boot chain against the journal the launch's healthcheck server is exporting, through
+    /// the same observer fan-out the Enclave registers.
+    async fn run_boot_chain(launch: &TestLaunch, fail: bool) -> Result<(), BootError> {
+        let observers = Observers::new(vec![
+            Box::new(LogObserver),
+            Box::new(launch.boot_journal.clone()),
+        ]);
+        let boot_context = BootContext::new(Arc::new(observers), launch.agent.shutdown_notifier());
+
+        BootChain::seed(boot_context, ())
+            .then(LoadEnvironment { fail })
+            .run()
+            .await
+    }
+
+    /// A healthcheck response as the host sees it. Everything below asserts against the serialized
+    /// body rather than the agent's in-process verdict, because the body is what crosses the bridge.
+    struct HealthResponse {
+        status_code: u16,
+        content_type: Option<String>,
+        body: String,
+    }
+
+    /// Poll the healthcheck the way the host does.
+    ///
+    /// `accept` names the formats the caller understands. `None` is not a placeholder: it is what a
+    /// caller predating format negotiation sends, and the case the default exists to serve.
+    async fn get_health(launch: &TestLaunch, accept: Option<String>) -> HealthResponse {
+        let mut request = Request::builder()
+            .method("GET")
+            .uri(format!("http://{}/", launch.address));
+        if let Some(accept) = accept {
+            request = request.header(header::ACCEPT, accept);
+        }
+
+        let response = hyper::Client::new()
+            .request(
+                request
+                    .body(Body::empty())
+                    .expect("Failed to build the healthcheck test request"),
+            )
+            .await
+            .expect("Failed to reach the healthcheck server");
+
+        let status_code = response.status().as_u16();
+        let content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let body = hyper::body::to_bytes(response.into_body())
+            .await
+            .expect("Failed to read the healthcheck response body");
+
+        HealthResponse {
+            status_code,
+            content_type,
+            body: String::from_utf8(body.to_vec()).expect("The healthcheck body should be UTF-8"),
+        }
+    }
+
+    /// Read a response as v1, asserting it was served as v1 on the way.
+    fn expect_v1(response: &HealthResponse) -> DataPlaneState {
+        assert_eq!(
+            response.content_type.as_deref(),
+            Some(HealthCheckFormat::V1.content_type())
+        );
+
+        serde_json::from_str(&response.body)
+            .expect("Failed to deserialize the healthcheck response")
+    }
+
+    fn expect_initialized(state: DataPlaneState) -> DataPlaneDiagnostic {
+        match state {
+            DataPlaneState::Initialized(diagnostic) => diagnostic,
+            other => panic!("Expected an initialized data plane, got - {other:?}"),
+        }
+    }
+
+    /// Read a response as v2, asserting it was served as v2 on the way.
+    fn expect_v2(response: &HealthResponse) -> DataPlaneHealth {
+        assert_eq!(
+            response.content_type.as_deref(),
+            Some(HealthCheckFormat::V2.content_type())
+        );
+
+        serde_json::from_str(&response.body)
+            .expect("Failed to deserialize the healthcheck response")
+    }
+
+    /// A caller that names no format is served v1, unchanged. This is the rarer skew — a freshly
+    /// built Enclave polled by a control plane that has not rolled forward — but it is the one the
+    /// default exists for, since such a caller cannot parse anything it did not ask for.
+    ///
+    /// Boot diagnostics are a v2 addition, so this body is the one the Enclave has always served
+    /// even with warnings recorded. Asserting it whole is what pins that.
+    #[tokio::test]
+    async fn it_serves_the_unchanged_v1_body_to_a_caller_that_names_no_format() {
+        // A service which never returns, mirroring an Enclave whose critical services are all up.
+        let launch = spawn_launch(|_| pending()).await;
+
+        run_boot_chain(&launch, false)
+            .await
+            .expect("The boot chain should have succeeded");
+
+        let response = get_health(&launch, None).await;
+        assert_eq!(response.status_code, 200);
+        assert_eq!(
+            response.content_type.as_deref(),
+            Some(HealthCheckFormat::V1.content_type())
+        );
+        assert_eq!(
+            response.body,
+            r#"{"Initialized":{"user_process":{"Unknown":"Enclave is not initialized yet"}}}"#
+        );
+
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    /// A caller that names only v1 is served v1, even though this data plane can serve more.
+    #[tokio::test]
+    async fn it_serves_v1_to_a_caller_that_names_only_v1() {
+        let launch = spawn_launch(|_| pending()).await;
+
+        let response = get_health(
+            &launch,
+            Some(HealthCheckFormat::V1.content_type().to_string()),
+        )
+        .await;
+
+        assert_eq!(
+            response.content_type.as_deref(),
+            Some(HealthCheckFormat::V1.content_type())
+        );
+    }
+
+    /// v2 puts the boot report beside the state, so a consumer reads what boot saw without having
+    /// to reach through `Initialized` — and without the data plane having reached it.
+    #[tokio::test]
+    async fn it_serves_boot_warnings_beside_the_state_to_a_caller_that_asks_for_v2() {
+        let launch = spawn_launch(|_| pending()).await;
+
+        run_boot_chain(&launch, false)
+            .await
+            .expect("The boot chain should have succeeded");
+
+        let response = get_health(&launch, Some(HealthCheckFormat::accept_header())).await;
+        assert_eq!(response.status_code, 200);
+
+        let health = expect_v2(&response);
+        // A boot warning is context for an operator, never a verdict.
+        assert!(
+            health.is_healthy(),
+            "A boot warning flipped the Enclave's health verdict"
+        );
+        assert_eq!(health.status_code(), 200);
+
+        let diagnostic = expect_initialized(health.state);
+        assert_eq!(
+            diagnostic.user_process,
+            UserProcessHealth::Unknown("Enclave is not initialized yet".to_string())
+        );
+
+        // No stage is in flight once the chain has run to completion.
+        assert_eq!(health.boot.stage, None);
+        // Only the warning is exported. The informational diagnostic stops at the log.
+        assert_eq!(health.boot.diagnostics.len(), 1);
+        assert_eq!(health.boot.diagnostics[0].stage, "load-environment");
+        assert_eq!(
+            health.boot.diagnostics[0].code,
+            "env.malformed-variable-dropped"
+        );
+        assert_eq!(
+            health.boot.diagnostics[0].message,
+            "dropped 1 malformed environment variable"
+        );
+        assert_eq!(health.boot.dropped, 0);
+
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    #[tokio::test]
+    async fn it_names_the_failing_stage_to_a_caller_that_asks_for_v2() {
+        let launch = spawn_launch(|_| pending()).await;
+
+        let error = run_boot_chain(&launch, true)
+            .await
+            .expect_err("The boot chain should have surfaced the stage's failure");
+        assert!(matches!(error, BootError::Io(_)));
+
+        let response = get_health(&launch, Some(HealthCheckFormat::accept_header())).await;
+        assert_eq!(response.status_code, 200);
+
+        let health = expect_v2(&response);
+        // The report goes on naming the stage that broke, and keeps what it recorded on the way.
+        assert_eq!(health.boot.stage.as_deref(), Some("load-environment"));
+        assert_eq!(health.boot.diagnostics.len(), 1);
+        assert_eq!(
+            health.boot.diagnostics[0].code,
+            "env.malformed-variable-dropped"
+        );
+
+        assert_still_serving_healthchecks(&launch);
+    }
+
+    /// The two formats describe one reading of one Enclave. v2 wraps the state v1 serves rather
+    /// than restating it, and this is what holds it to that.
+    #[tokio::test]
+    async fn both_formats_report_the_same_state() {
+        let launch = spawn_launch(|_| pending()).await;
+
+        run_boot_chain(&launch, false)
+            .await
+            .expect("The boot chain should have succeeded");
+
+        let v1 = get_health(&launch, None).await;
+        let v2 = get_health(&launch, Some(HealthCheckFormat::accept_header())).await;
+
+        let v1_state = expect_v1(&v1);
+        let v2_health = expect_v2(&v2);
+
+        assert_eq!(v1_state.status_code(), v2_health.status_code());
+        assert_eq!(v1_state.is_healthy(), v2_health.is_healthy());
+        assert_eq!(
+            expect_initialized(v1_state).user_process,
+            expect_initialized(v2_health.state).user_process
+        );
     }
 }

--- a/crates/shared/src/server/health.rs
+++ b/crates/shared/src/server/health.rs
@@ -1,5 +1,76 @@
 use serde::{Deserialize, Serialize};
 
+/// The body formats the Enclave's healthcheck can be served as.
+///
+/// The two sides of the bridge age at different rates. The control plane rolls forward on its own;
+/// the data plane is baked into the Enclave image and only moves when that image is rebuilt, so the
+/// Enclave is almost always the older of the two. Negotiation is what lets the newer control plane
+/// ask for a format without assuming the Enclave can produce one: an Enclave predating a format
+/// ignores the request and answers as it always has, and [`HealthCheckVersion::parse`] reads that
+/// answer for what it is.
+///
+/// The Enclave answers in [`HealthCheckFormat::V1`] unless the caller names something newer. That
+/// default covers the rarer reverse skew — a freshly built Enclave polled by a control plane that
+/// has not rolled forward yet — where a body the caller cannot parse reads to the host as an
+/// Enclave that cannot be reached at all.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HealthCheckFormat {
+    /// [`DataPlaneState`] — the data plane's state, with everything it knows nested under
+    /// `Initialized`.
+    #[default]
+    V1,
+    /// [`DataPlaneHealth`] — the state and everything the data plane knows, side by side.
+    V2,
+}
+
+impl HealthCheckFormat {
+    /// Every format a caller can name, newest first. This is the preference order
+    /// [`from_accept`](Self::from_accept) resolves in.
+    const NEWEST_FIRST: [Self; 2] = [Self::V2, Self::V1];
+
+    /// The `Content-Type` the Enclave answers with, and the token a caller puts in `Accept`.
+    pub fn content_type(self) -> &'static str {
+        match self {
+            Self::V1 => "application/json;version=1",
+            Self::V2 => "application/json;version=2",
+        }
+    }
+
+    /// The `Accept` header naming every format the caller understands, newest first.
+    pub fn accept_header() -> String {
+        Self::NEWEST_FIRST.map(Self::content_type).join(", ")
+    }
+
+    /// The newest format the caller named, falling back to the default when it named none this
+    /// Enclave knows.
+    ///
+    /// Entries are matched whole rather than by substring: `version=20` contains `version=2`, and
+    /// answering a caller in a format it never asked for is the one failure this must not have.
+    pub fn from_accept(accept: Option<&str>) -> Self {
+        let Some(accept) = accept else {
+            return Self::default();
+        };
+
+        Self::NEWEST_FIRST
+            .into_iter()
+            .find(|format| {
+                accept
+                    .split(',')
+                    .any(|entry| entry.trim() == format.content_type())
+            })
+            .unwrap_or_default()
+    }
+
+    /// The format a response body is in, read from its `Content-Type`. `None` for a body served
+    /// before the header carried a version at all.
+    pub fn from_content_type(content_type: Option<&str>) -> Option<Self> {
+        let content_type = content_type?.trim();
+        Self::NEWEST_FIRST
+            .into_iter()
+            .find(|format| format.content_type() == content_type)
+    }
+}
+
 /// This is for representing healthcheck verions across the control-plane <-> data-plane http
 /// boundary. It's not tied to v0/v1 enclaves release. There are many v1 enclaves that will
 /// report v0 healthchecks until they are updated.
@@ -8,6 +79,7 @@ use serde::{Deserialize, Serialize};
 pub enum HealthCheckVersion {
     V0(HealthCheckLog),
     V1(DataPlaneState),
+    V2(DataPlaneHealth),
 }
 
 impl HealthCheckVersion {
@@ -15,13 +87,32 @@ impl HealthCheckVersion {
         match self {
             HealthCheckVersion::V0(log) => log.status_code(),
             HealthCheckVersion::V1(dp_state) => dp_state.status_code(),
+            HealthCheckVersion::V2(dp_health) => dp_health.status_code(),
         }
+    }
+
+    /// Read a healthcheck body in whichever format its `Content-Type` names.
+    ///
+    /// Keeping the mapping here means a new format costs one arm in this file, rather than an edit
+    /// everywhere a healthcheck is read.
+    pub fn parse(content_type: Option<&str>, body: &[u8]) -> serde_json::Result<Self> {
+        Ok(match HealthCheckFormat::from_content_type(content_type) {
+            Some(HealthCheckFormat::V2) => Self::V2(serde_json::from_slice(body)?),
+            Some(HealthCheckFormat::V1) => Self::V1(serde_json::from_slice(body)?),
+            None => Self::V0(serde_json::from_slice(body)?),
+        })
     }
 }
 
 impl From<DataPlaneState> for HealthCheckVersion {
     fn from(state: DataPlaneState) -> Self {
         HealthCheckVersion::V1(state)
+    }
+}
+
+impl From<DataPlaneHealth> for HealthCheckVersion {
+    fn from(health: DataPlaneHealth) -> Self {
+        HealthCheckVersion::V2(health)
     }
 }
 
@@ -95,9 +186,10 @@ impl HealthCheck for ControlPlaneState {
 
 impl HealthCheck for DataPlaneState {
     fn status_code(&self) -> u16 {
-        match self {
-            DataPlaneState::Initialized(diagnostic) if diagnostic.is_healthy() => 200,
-            _ => 500,
+        if self.is_healthy() {
+            200
+        } else {
+            500
         }
     }
 }
@@ -108,6 +200,12 @@ impl HealthCheck for HealthCheckLog {
     }
 }
 
+/// What the data plane's healthcheck reports, as [`HealthCheckFormat::V1`] serves it.
+///
+/// `Error` and `Unknown` are **control plane constructs**: the string they carry is the control
+/// plane's own commentary on an Enclave it could not reach, or is deliberately not polling. The
+/// data plane never produces either — it reports what it observed, and has no free-form slot to
+/// write into.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DataPlaneState {
     Error(String),
@@ -118,18 +216,129 @@ pub enum DataPlaneState {
     Initialized(DataPlaneDiagnostic),
 }
 
+impl DataPlaneState {
+    /// Only an initialized data plane whose user process is answering is healthy. Every other state
+    /// is the Enclave still on its way up, or a control plane reporting that it could not be
+    /// reached.
+    pub fn is_healthy(&self) -> bool {
+        matches!(self, DataPlaneState::Initialized(diagnostic) if diagnostic.is_healthy())
+    }
+}
+
+/// One thing the Enclave's boot sequence had to say about a stage beyond whether it succeeded.
+///
+/// Carries names, codes and counts only. Producers must never interpolate a value — an environment
+/// variable's contents, a secret, key or certificate material — into `message`, because this
+/// travels to the host and is recorded by the control plane.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct BootDiagnostic {
+    /// The boot stage that recorded it, stamped by the data plane rather than by the stage itself.
+    pub stage: String,
+    /// Stable and greppable, e.g. `"env.malformed-variable-dropped"`. This is what a consumer
+    /// groups and alerts on; `message` is for a human reading one instance.
+    pub code: String,
+    pub message: String,
+}
+
+/// What the Enclave's boot sequence recorded, as exported in the healthcheck body.
+///
+/// A boot which succeeded with nothing to report leaves every field at its default, and each field
+/// is skipped when empty — so a clean boot serializes to nothing at all and the enclosing body is
+/// byte-identical to one produced with no boot reporting whatsoever. Consumers that do not know
+/// about this field are unaffected; consumers that do can read a *successful but imperfect* boot for
+/// as long as the Enclave is up, which no free-form status string survives.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct BootReport {
+    /// The stage boot is in, or the stage it was in when it encountered issues.
+    /// `None` when no stage is in flight, which covers both "boot finished" and
+    /// "boot never started".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<BootDiagnostic>,
+    /// Diagnostics discarded after the report hit the data plane's cap. Present so that a truncated
+    /// report is never mistaken for a complete one.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub dropped: u32,
+}
+
+impl BootReport {
+    /// Whether the report is worth serializing at all.
+    pub fn is_empty(&self) -> bool {
+        self.stage.is_none() && self.diagnostics.is_empty() && self.dropped == 0
+    }
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DataPlaneDiagnostic {
     pub user_process: UserProcessHealth,
 }
 
 impl DataPlaneDiagnostic {
+    pub fn new(user_process: UserProcessHealth) -> Self {
+        Self { user_process }
+    }
+
     pub fn is_healthy(&self) -> bool {
-        match self.user_process {
-            UserProcessHealth::Unknown(_) => true,
-            UserProcessHealth::Error(_) => false,
-            UserProcessHealth::Response { status_code, .. } => (200..300).contains(&status_code),
+        self.user_process.is_healthy()
+    }
+}
+
+/// The data plane's state and the diagnostics its boot sequence recorded, side by side.
+///
+/// This is the shape [`HealthCheckFormat::V2`] serves, and it wraps the same [`DataPlaneState`] v1
+/// reports rather than restating it — so the control plane's `Error` and `Unknown` messages, and
+/// the reading v1 nests under `Initialized`, all arrive unchanged.
+///
+/// What v2 adds is `boot`. In v1 the only place for a diagnostic is inside `Initialized`, so a data
+/// plane that failed or is still coming up has nowhere to say what it saw — exactly when an
+/// operator most wants to know. Lifting it beside the state means every state can carry one.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DataPlaneHealth {
+    pub state: DataPlaneState,
+    /// What the boot sequence recorded, in whatever state the data plane reached.
+    #[serde(default, skip_serializing_if = "BootReport::is_empty")]
+    pub boot: BootReport,
+}
+
+impl DataPlaneHealth {
+    pub fn new(state: DataPlaneState) -> Self {
+        Self {
+            state,
+            boot: BootReport::default(),
         }
+    }
+
+    pub fn with_boot(mut self, boot: BootReport) -> Self {
+        self.boot = boot;
+        self
+    }
+
+    /// Defers to the state. A boot report is context for an operator, not a verdict: it must never
+    /// flip the Enclave's health or its healthcheck status code.
+    pub fn is_healthy(&self) -> bool {
+        self.state.is_healthy()
+    }
+}
+
+impl HealthCheck for DataPlaneHealth {
+    fn status_code(&self) -> u16 {
+        self.state.status_code()
+    }
+}
+
+/// Render a v2 body as the v1 body an Enclave or control plane predating v2 expects.
+///
+/// The state crosses untouched; the boot report is what v1 has nowhere to put. That single loss is
+/// the whole reason v2 exists, and building v2 once and downgrading — rather than building each
+/// version separately — is what keeps the two from disagreeing about anything else.
+impl From<DataPlaneHealth> for DataPlaneState {
+    fn from(health: DataPlaneHealth) -> Self {
+        health.state
     }
 }
 
@@ -144,6 +353,18 @@ pub enum UserProcessHealth {
 }
 
 impl UserProcessHealth {
+    /// Whether this reading should let the Enclave report itself healthy.
+    ///
+    /// `Unknown` does: it means nothing has been observed yet, which is not evidence of ill health.
+    /// Both healthcheck body formats defer to this, so neither can drift from the other.
+    pub fn is_healthy(&self) -> bool {
+        match self {
+            Self::Unknown(_) => true,
+            Self::Error(_) => false,
+            Self::Response { status_code, .. } => (200..300).contains(status_code),
+        }
+    }
+
     pub fn rank(&self) -> u8 {
         match self {
             UserProcessHealth::Unknown(_) => 0,
@@ -178,7 +399,6 @@ impl PartialOrd for UserProcessHealth {
 #[cfg(test)]
 mod test {
     use super::*;
-
     #[tokio::test]
     async fn it_returns_errors_over_healthy_up_responses() {
         let max = [
@@ -231,5 +451,286 @@ mod test {
                 body: None,
             }
         ));
+    }
+
+    fn user_process() -> UserProcessHealth {
+        UserProcessHealth::Response {
+            status_code: 200,
+            body: None,
+        }
+    }
+
+    fn initialized() -> DataPlaneState {
+        DataPlaneState::Initialized(DataPlaneDiagnostic::new(user_process()))
+    }
+
+    fn populated_report() -> BootReport {
+        BootReport {
+            stage: Some("load-environment".to_string()),
+            diagnostics: vec![BootDiagnostic {
+                stage: "load-environment".to_string(),
+                code: "env.malformed-variable-dropped".to_string(),
+                message: "dropped 1 malformed environment variable".to_string(),
+            }],
+            dropped: 3,
+        }
+    }
+
+    fn v2_health() -> DataPlaneHealth {
+        DataPlaneHealth::new(initialized()).with_boot(populated_report())
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Format negotiation. The Enclave must never answer in a format the caller did not name.
+    // ---------------------------------------------------------------------------------------
+
+    #[test]
+    fn a_caller_naming_no_format_gets_the_default() {
+        assert_eq!(HealthCheckFormat::from_accept(None), HealthCheckFormat::V1);
+        assert_eq!(
+            HealthCheckFormat::from_accept(Some("text/plain")),
+            HealthCheckFormat::V1
+        );
+        assert_eq!(
+            HealthCheckFormat::from_accept(Some("")),
+            HealthCheckFormat::V1
+        );
+    }
+
+    #[test]
+    fn a_caller_gets_the_newest_format_it_named() {
+        assert_eq!(
+            HealthCheckFormat::from_accept(Some("application/json;version=2")),
+            HealthCheckFormat::V2
+        );
+        assert_eq!(
+            HealthCheckFormat::from_accept(Some(&HealthCheckFormat::accept_header())),
+            HealthCheckFormat::V2
+        );
+        assert_eq!(
+            HealthCheckFormat::from_accept(Some("application/json;version=1")),
+            HealthCheckFormat::V1
+        );
+    }
+
+    /// Entries are matched whole. A substring match would read `version=20` as v2 and answer a
+    /// caller in a format it cannot parse.
+    #[test]
+    fn a_format_this_enclave_does_not_know_is_not_mistaken_for_one_it_does() {
+        assert_eq!(
+            HealthCheckFormat::from_accept(Some("application/json;version=20")),
+            HealthCheckFormat::V1
+        );
+    }
+
+    #[test]
+    fn a_response_is_read_in_the_format_its_content_type_names() {
+        assert_eq!(HealthCheckFormat::from_content_type(None), None);
+        assert_eq!(
+            HealthCheckFormat::from_content_type(Some("application/json;version=1")),
+            Some(HealthCheckFormat::V1)
+        );
+        assert_eq!(
+            HealthCheckFormat::from_content_type(Some("application/json;version=2")),
+            Some(HealthCheckFormat::V2)
+        );
+        // A body served before the header carried a version at all.
+        assert_eq!(
+            HealthCheckFormat::from_content_type(Some("application/json")),
+            None
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Untagged discrimination. `HealthCheckVersion` picks the first variant that parses, so a
+    // body read as the wrong version fails silently rather than loudly. Assert it directly.
+    // ---------------------------------------------------------------------------------------
+
+    fn parse_as_served(
+        format: Option<HealthCheckFormat>,
+        value: &impl Serialize,
+    ) -> HealthCheckVersion {
+        let body = serde_json::to_vec(value).unwrap();
+        HealthCheckVersion::parse(format.map(HealthCheckFormat::content_type), &body).unwrap()
+    }
+
+    #[test]
+    fn each_format_is_read_back_as_the_version_it_was_served_as() {
+        let v0 = HealthCheckLog::new(HealthCheckStatus::Ok, Some("up".to_string()));
+
+        assert!(matches!(
+            parse_as_served(None, &v0),
+            HealthCheckVersion::V0(_)
+        ));
+        assert!(matches!(
+            parse_as_served(Some(HealthCheckFormat::V1), &initialized()),
+            HealthCheckVersion::V1(_)
+        ));
+        assert!(matches!(
+            parse_as_served(Some(HealthCheckFormat::V2), &v2_health()),
+            HealthCheckVersion::V2(_)
+        ));
+    }
+
+    /// The control plane nests a `HealthCheckVersion` in its own log and reads it back untagged,
+    /// with no `Content-Type` to lean on. Every version has to survive that round trip as itself —
+    /// and v2 wrapping the same `DataPlaneState` v1 reports is exactly where that could go wrong.
+    #[test]
+    fn every_version_survives_an_untagged_round_trip_as_itself() {
+        let versions = [
+            HealthCheckVersion::V0(HealthCheckLog::new(HealthCheckStatus::Ok, None)),
+            HealthCheckVersion::V1(DataPlaneState::Provisioning),
+            HealthCheckVersion::V1(initialized()),
+            HealthCheckVersion::V2(v2_health()),
+            HealthCheckVersion::V2(DataPlaneHealth::new(DataPlaneState::Provisioning)),
+            HealthCheckVersion::V2(DataPlaneHealth::new(DataPlaneState::Error(
+                "could not be reached".to_string(),
+            ))),
+        ];
+
+        for version in versions {
+            let encoded = serde_json::to_string(&version).unwrap();
+            let decoded: HealthCheckVersion = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(
+                std::mem::discriminant(&version),
+                std::mem::discriminant(&decoded),
+                "{encoded} was read back as a different version"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The verdict. v2 wraps the state rather than restating it, and must not reinterpret it.
+    // ---------------------------------------------------------------------------------------
+
+    #[test]
+    fn both_formats_return_the_same_status_code_for_the_same_state() {
+        let states = [
+            DataPlaneState::Unknown("draining".to_string()),
+            DataPlaneState::Error("unreachable".to_string()),
+            DataPlaneState::Provisioning,
+            DataPlaneState::Attesting,
+            DataPlaneState::SourcingTlsCerts,
+            DataPlaneState::Initialized(DataPlaneDiagnostic::new(UserProcessHealth::Unknown(
+                "nothing read yet".to_string(),
+            ))),
+            DataPlaneState::Initialized(DataPlaneDiagnostic::new(UserProcessHealth::Error(
+                "the user process is gone".to_string(),
+            ))),
+            initialized(),
+            DataPlaneState::Initialized(DataPlaneDiagnostic::new(UserProcessHealth::Response {
+                status_code: 503,
+                body: None,
+            })),
+        ];
+
+        for state in states {
+            for boot in [BootReport::default(), populated_report()] {
+                let health = DataPlaneHealth::new(state.clone()).with_boot(boot);
+
+                assert_eq!(
+                    health.status_code(),
+                    state.status_code(),
+                    "v2 reinterpreted {state:?}"
+                );
+                assert_eq!(health.is_healthy(), state.is_healthy());
+            }
+        }
+    }
+
+    /// Only an initialized data plane answering healthily is healthy, and a boot report never
+    /// changes that in either format.
+    #[test]
+    fn a_boot_report_is_never_a_verdict() {
+        let healthy = DataPlaneHealth::new(initialized()).with_boot(populated_report());
+        assert!(healthy.is_healthy());
+        assert_eq!(healthy.status_code(), 200);
+
+        let provisioning =
+            DataPlaneHealth::new(DataPlaneState::Provisioning).with_boot(populated_report());
+        assert!(!provisioning.is_healthy());
+        assert_eq!(provisioning.status_code(), 500);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The v2 body itself.
+    // ---------------------------------------------------------------------------------------
+
+    /// The reason v2 exists: a data plane that never reached `Initialized` still reports what boot
+    /// saw, where v1 has nowhere to put it.
+    #[test]
+    fn a_boot_report_survives_in_a_state_v1_cannot_carry_one_in() {
+        let health =
+            DataPlaneHealth::new(DataPlaneState::Provisioning).with_boot(populated_report());
+
+        let encoded = serde_json::to_string(&health).unwrap();
+        let decoded: DataPlaneHealth = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.boot, populated_report());
+
+        // Downgrading to v1 is where it is lost, which is what v2 is for.
+        assert!(matches!(
+            DataPlaneState::from(health),
+            DataPlaneState::Provisioning
+        ));
+    }
+
+    #[test]
+    fn a_v2_body_omits_a_boot_report_it_has_nothing_to_put_in() {
+        assert_eq!(
+            serde_json::to_string(&DataPlaneHealth::new(DataPlaneState::Provisioning)).unwrap(),
+            r#"{"state":"Provisioning"}"#
+        );
+    }
+
+    /// The state arrives exactly as v1 writes it, with the boot report beside it rather than buried
+    /// inside it.
+    #[test]
+    fn a_v2_body_wraps_the_v1_state_and_puts_the_boot_report_beside_it() {
+        assert_eq!(
+            serde_json::to_string(&v2_health()).unwrap(),
+            concat!(
+                r#"{"state":{"Initialized":{"user_process":{"Response":{"status_code":200,"body":null}}}},"#,
+                r#""boot":{"stage":"load-environment","#,
+                r#""diagnostics":[{"stage":"load-environment","#,
+                r#""code":"env.malformed-variable-dropped","#,
+                r#""message":"dropped 1 malformed environment variable"}],"dropped":3}}"#
+            )
+        );
+    }
+
+    /// The control plane's own commentary rides in the state, so v2 needs no free-form slot of its
+    /// own and the control plane never has to fall back to an older format to be heard.
+    #[test]
+    fn a_v2_body_carries_the_control_planes_message_in_the_state() {
+        let health = DataPlaneHealth::new(DataPlaneState::Error(
+            "Failed to contact data-plane for healthcheck".to_string(),
+        ));
+
+        assert_eq!(
+            serde_json::to_string(&health).unwrap(),
+            r#"{"state":{"Error":"Failed to contact data-plane for healthcheck"}}"#
+        );
+    }
+
+    /// Downgrading is how the data plane answers a caller that predates v2. The state has to cross
+    /// untouched; the boot report is the one thing v1 has no room for.
+    #[test]
+    fn downgrading_keeps_the_state_and_drops_only_the_boot_report() {
+        let DataPlaneState::Initialized(diagnostic) = DataPlaneState::from(v2_health()) else {
+            panic!("Expected an initialized data plane");
+        };
+
+        assert_eq!(diagnostic.user_process, user_process());
+    }
+
+    #[test]
+    fn a_report_is_empty_only_while_every_field_is() {
+        assert!(BootReport::default().is_empty());
+        assert!(!populated_report().is_empty());
+        assert!(!BootReport {
+            dropped: 1,
+            ..BootReport::default()
+        }
+        .is_empty());
     }
 }


### PR DESCRIPTION
# Why

Stacked on #337 

In order to make the launcher chain more useful than an abstraction on critical workflows, this PR extends the interface to give us diagnostics support. This should unlock the reporting of non-fatal errors and graceful degradations that may occur within the enclave launch process.

Each diagnostic is emitted explicitly by a stage of the launcher. There must be care taken to ensure that the diagnostics only reveal a minimal amount of safe data.

# How

- Add a diagnostic callback to the boot context object passed into each stage. This allows the stage to produce its own diagnostic reports
- The diagnostic callback is then extended to the observer which receives all lifecycle events of the launcher chain. The observer can then direct this context as appropriate.
- Evolved the control plane -> data plane healthchecks to include a new diagnostics property which allows arbitrary diagnostics to be reported to the host.